### PR TITLE
Api update signup

### DIFF
--- a/src/backend/database/create-schema.psql
+++ b/src/backend/database/create-schema.psql
@@ -1,4 +1,7 @@
 DROP TABLE IF EXISTS "account" CASCADE;
+DROP TABLE IF EXISTS "province" CASCADE;
+DROP TABLE IF EXISTS "district" CASCADE;
+DROP TABLE IF EXISTS "ward" CASCADE;
 DROP TABLE IF EXISTS "shipping_address" CASCADE;
 DROP TABLE IF EXISTS "category" CASCADE;
 DROP TABLE IF EXISTS "payment" CASCADE;
@@ -24,7 +27,6 @@ CREATE TABLE "account" (
   "password" char(64),
   "phone" varchar UNIQUE,
   "fullname" varchar,
-  "address" varchar,
   "birthday" date,
   "gender" varchar,
   "avatar" varchar,
@@ -33,10 +35,30 @@ CREATE TABLE "account" (
   "otp" varchar
 );
 
+CREATE TABLE "province" (
+  "id" int PRIMARY KEY,
+  "province_name" varchar 
+);
+
+CREATE TABLE "district" (
+  "id" int PRIMARY KEY,
+  "district_name" varchar,
+  "province_id" int
+);
+
+CREATE TABLE "ward" (
+  "id" int PRIMARY KEY,
+  "ward_name" varchar,
+  "district_id" int
+);
+
 CREATE TABLE "shipping_address" (
   "id" SERIAL PRIMARY KEY,
   "email" varchar,
-  "shipping_address" varchar,
+  "province_id" int,
+  "district_id" int,
+  "ward_id" int,
+  "address" varchar,
   "receiver_phone" varchar,
   "receiver_name" varchar
 );
@@ -55,38 +77,38 @@ CREATE TABLE "payment" (
 
 CREATE TABLE "product" (
   "id" SERIAL PRIMARY KEY,
-  "name" varchar,
+  "name" varchar NOT NULL,
   "category_id" int,
   "description" varchar,
-  "avg_rating" float,
-  "count_rating" int
+  "avg_rating" real CHECK(avg_rating>=0) CHECK(avg_rating<=5),
+  "count_rating" int NOT NULL DEFAULT 0 CHECK(count_rating>=0)
 );
 
 CREATE TABLE "product_image" (
   "id" SERIAL PRIMARY KEY,
   "product_id" int,
-  "path" varchar,
-  "is_primary" boolean
+  "path" varchar NOT NULL,
+  "is_primary" boolean 
 );
 
 CREATE TABLE "option" (
   "id" SERIAL PRIMARY KEY,
-  "name" varchar
+  "name" varchar NOT NULL
 );
 
 CREATE TABLE "option_choice" (
   "id" SERIAL PRIMARY KEY,
   "option_id" int,
   "product_id" int,
-  "choice_name" varchar
+  "choice_name" varchar NOT NULL
 );
 
 CREATE TABLE "variant" (
   "id" SERIAL PRIMARY KEY,
   "product_id" int,
-  "price" real,
+  "price" real NOT NULL,
   "discount_price" real,
-  "stock" int
+  "stock" int NOT NULL
 );
 
 CREATE TABLE "variant_option_choice" (
@@ -99,19 +121,19 @@ CREATE TABLE "order" (
   "id" SERIAL PRIMARY KEY,
   "email" varchar,
   "created_time" timestamp,
-  "payment_id" int,
-  "shipping_address_id" int,
-  "total" real,
-  "shipping_provider_id" int,
-  "shipping_price" real,
+  "payment_id" int NOT NULL,
+  "shipping_address_id" int NOT NULL,
+  "total" real NOT NULL,
+  "shipping_provider_id" int NOT NULL,
+  "shipping_price" real NOT NULL,
   "voucher_id" int
 );
 
 CREATE TABLE "order_variant" (
   "order_id" int,
   "variant_id" int,
-  "quantity" int,
-  "variant_price" real,
+  "quantity" int NOT NULL,
+  "variant_price" real NOT NULL,
   PRIMARY KEY ("order_id", "variant_id")
 );
 
@@ -137,28 +159,33 @@ CREATE TABLE "review" (
 
 CREATE TABLE "shipping_provider" (
   "id" SERIAL PRIMARY KEY,
-  "name" varchar,
-  "email" varchar,
-  "phone" varchar UNIQUE
+  "name" varchar
 );
 
 CREATE TABLE "order_state" (
   "order_id" int,
-  "state" varchar,
-  "created_time" timestamp,
+  "state" varchar NOT NULL,
+  "created_time" timestamp NOT NULL,
   PRIMARY KEY ("order_id", "state")
 );
 
 CREATE TABLE "voucher" (
   "id" SERIAL PRIMARY KEY,
-  "discount" bigint,
-  "minimum_price" bigint,
-  "start_date" timestamp,
+  "voucher_code" varchar UNIQUE NOT NULL,
+  "discount" real NOT NULL,
+  "minimum_price" real,
+  "start_date" timestamp NOT NULL,
   "end_date" timestamp
 );
 
 ----------------------- CONSTRAINT -------------------------
 
+ALTER TABLE "district" ADD FOREIGN KEY ("province_id") REFERENCES "province"("id");
+ALTER TABLE "ward" ADD FOREIGN KEY ("district_id") REFERENCES "district"("id");
+
+ALTER TABLE "shipping_address" ADD FOREIGN KEY("province_id") REFERENCES "province"("id");
+ALTER TABLE "shipping_address" ADD FOREIGN KEY("district_id") REFERENCES "district"("id");
+ALTER TABLE "shipping_address" ADD FOREIGN KEY("ward_id") REFERENCES "ward"("id");
 ALTER TABLE "shipping_address" ADD FOREIGN KEY ("email") REFERENCES "account" ("email");
 
 ALTER TABLE "order" ADD FOREIGN KEY ("email") REFERENCES "account" ("email");
@@ -199,22 +226,17 @@ ALTER TABLE "cart_variant" ADD FOREIGN KEY ("cart_id") REFERENCES "cart" ("id");
 
 -- Admin password: admin
 -- User password: user
-INSERT INTO "account"("email","password","phone","fullname","address","birthday","gender","avatar","account_type") VALUES('phuc16102001@gmail.com','c922a25f9b38b3a5a30c354246275af1dd5588d916ad8de33ba669f1b4ae32e4','0707953475','Đỗ Vương Phúc','1E/1 Bình Đông', '2001-10-16','male',NULL,'admin');
-INSERT INTO "account"("email","password","phone","fullname","address","birthday","gender","avatar","account_type") VALUES('thanhhoang4869@gmail.com','8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918','0933442607','Hoàng Như Thanh','125/72 Nguyễn Văn Thương','2001-07-26','female',NULL,'admin');
-INSERT INTO "account"("email","password","phone","fullname","address","birthday","gender","avatar","account_type") VALUES('nnhatdu@gmail.com','8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918','0987654321','Ngô Nhật Du',NULL,NULL,'female',NULL,'admin');
-INSERT INTO "account"("email","password","phone","fullname","address","birthday","gender","avatar","account_type") VALUES('longmydu@gmail.com','8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918','0987654322','Long Mỹ Du',NULL,NULL,'female',NULL,'admin');
-INSERT INTO "account"("email","password","phone","fullname","address","birthday","gender","avatar","account_type") VALUES('nhkduy201@gmail.com','8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918','0987654323','Nguyễn Hoàng Khánh Duy',NULL,NULL,'male',NULL,'admin');
-INSERT INTO "account"("email","password","phone","fullname","address","birthday","gender","avatar","account_type") VALUES('user1@gmail.com','04f8996da763b7a969b1028ee3007569eaf3a635486ddab211d512c85b9df8fb','0987654324','User 1',NULL,NULL,'female',NULL,'user');
-INSERT INTO "account"("email","password","phone","fullname","address","birthday","gender","avatar","account_type") VALUES('user2@gmail.com','04f8996da763b7a969b1028ee3007569eaf3a635486ddab211d512c85b9df8fb','0987654325','User 2',NULL,NULL,'male',NULL,'user');
-INSERT INTO "account"("email","password","phone","fullname","address","birthday","gender","avatar","account_type") VALUES('user3@gmail.com','04f8996da763b7a969b1028ee3007569eaf3a635486ddab211d512c85b9df8fb','0987654326','User 3',NULL,NULL,'female',NULL,'user');
-INSERT INTO "account"("email","password","phone","fullname","address","birthday","gender","avatar","account_type") VALUES('user4@gmail.com','04f8996da763b7a969b1028ee3007569eaf3a635486ddab211d512c85b9df8fb','0987654327','User 4',NULL,NULL,'male',NULL,'user');
-INSERT INTO "account"("email","password","phone","fullname","address","birthday","gender","avatar","account_type") VALUES('user5@gmail.com','04f8996da763b7a969b1028ee3007569eaf3a635486ddab211d512c85b9df8fb','0987654328','User 5',NULL,NULL,'female',NULL,'user');
+INSERT INTO "account"("email","password","phone","fullname","birthday","gender","avatar","account_type") VALUES('phuc16102001@gmail.com','c922a25f9b38b3a5a30c354246275af1dd5588d916ad8de33ba669f1b4ae32e4','0707953475','Đỗ Vương Phúc','2001-10-16','male',NULL,'admin');
+INSERT INTO "account"("email","password","phone","fullname","birthday","gender","avatar","account_type") VALUES('thanhhoang4869@gmail.com','8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918','0933442607','Hoàng Như Thanh','2001-07-26','female',NULL,'admin');
+INSERT INTO "account"("email","password","phone","fullname","birthday","gender","avatar","account_type") VALUES('nnhatdu@gmail.com','8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918','0987654321','Ngô Nhật Du',NULL,'female',NULL,'admin');
+INSERT INTO "account"("email","password","phone","fullname","birthday","gender","avatar","account_type") VALUES('longmydu@gmail.com','8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918','0987654322','Long Mỹ Du',NULL,'female',NULL,'admin');
+INSERT INTO "account"("email","password","phone","fullname","birthday","gender","avatar","account_type") VALUES('nhkduy201@gmail.com','8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918','0987654323','Nguyễn Hoàng Khánh Duy',NULL,'male',NULL,'admin');
+INSERT INTO "account"("email","password","phone","fullname","birthday","gender","avatar","account_type") VALUES('user1@gmail.com','04f8996da763b7a969b1028ee3007569eaf3a635486ddab211d512c85b9df8fb','0987654324','User 1',NULL,'female',NULL,'user');
+INSERT INTO "account"("email","password","phone","fullname","birthday","gender","avatar","account_type") VALUES('user2@gmail.com','04f8996da763b7a969b1028ee3007569eaf3a635486ddab211d512c85b9df8fb','0987654325','User 2',NULL,'male',NULL,'user');
+INSERT INTO "account"("email","password","phone","fullname","birthday","gender","avatar","account_type") VALUES('user3@gmail.com','04f8996da763b7a969b1028ee3007569eaf3a635486ddab211d512c85b9df8fb','0987654326','User 3',NULL,'female',NULL,'user');
+INSERT INTO "account"("email","password","phone","fullname","birthday","gender","avatar","account_type") VALUES('user4@gmail.com','04f8996da763b7a969b1028ee3007569eaf3a635486ddab211d512c85b9df8fb','0987654327','User 4',NULL,'male',NULL,'user');
+INSERT INTO "account"("email","password","phone","fullname","birthday","gender","avatar","account_type") VALUES('user5@gmail.com','04f8996da763b7a969b1028ee3007569eaf3a635486ddab211d512c85b9df8fb','0987654328','User 5',NULL,'female',NULL,'user');
 
-INSERT INTO "shipping_address"("email","shipping_address","receiver_phone","receiver_name") VALUES('user1@gmail.com','225 Nguyễn Tri Phương','0987654324','Người dùng 1.1');
-INSERT INTO "shipping_address"("email","shipping_address","receiver_phone","receiver_name") VALUES('user1@gmail.com','123 Nguyễn Văn Của','0987654324','Người dùng 1.2');
-INSERT INTO "shipping_address"("email","shipping_address","receiver_phone","receiver_name") VALUES('user2@gmail.com','123 Nguyễn Văn Của','0987654324','Người dùng 1.2');
-INSERT INTO "shipping_address"("email","shipping_address","receiver_phone","receiver_name") VALUES('user3@gmail.com','221 Lũy Bán Bích','0987654325','Người dùng 3.1');
-  
 INSERT INTO "payment"("provider") VALUES('paypal');
 INSERT INTO "payment"("provider") VALUES('momo');
 INSERT INTO "payment"("provider") VALUES('pickup');

--- a/src/backend/database/create-schema.psql
+++ b/src/backend/database/create-schema.psql
@@ -24,7 +24,7 @@ DROP TABLE IF EXISTS "voucher" CASCADE;
 
 CREATE TABLE "account" (
   "email" varchar PRIMARY KEY,
-  "password" char(64),
+  "password" varchar,
   "phone" varchar UNIQUE,
   "fullname" varchar,
   "birthday" date,
@@ -32,7 +32,7 @@ CREATE TABLE "account" (
   "avatar" varchar,
   "account_type" varchar,
   "verified" bool DEFAULT false,
-  "otp" varchar
+  "token" char(64)
 );
 
 CREATE TABLE "province" (
@@ -226,16 +226,16 @@ ALTER TABLE "cart_variant" ADD FOREIGN KEY ("cart_id") REFERENCES "cart" ("id");
 
 -- Admin password: admin
 -- User password: user
-INSERT INTO "account"("email","password","phone","fullname","birthday","gender","avatar","account_type") VALUES('phuc16102001@gmail.com','c922a25f9b38b3a5a30c354246275af1dd5588d916ad8de33ba669f1b4ae32e4','0707953475','Đỗ Vương Phúc','2001-10-16','male',NULL,'admin');
-INSERT INTO "account"("email","password","phone","fullname","birthday","gender","avatar","account_type") VALUES('thanhhoang4869@gmail.com','8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918','0933442607','Hoàng Như Thanh','2001-07-26','female',NULL,'admin');
-INSERT INTO "account"("email","password","phone","fullname","birthday","gender","avatar","account_type") VALUES('nnhatdu@gmail.com','8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918','0987654321','Ngô Nhật Du',NULL,'female',NULL,'admin');
-INSERT INTO "account"("email","password","phone","fullname","birthday","gender","avatar","account_type") VALUES('longmydu@gmail.com','8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918','0987654322','Long Mỹ Du',NULL,'female',NULL,'admin');
-INSERT INTO "account"("email","password","phone","fullname","birthday","gender","avatar","account_type") VALUES('nhkduy201@gmail.com','8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918','0987654323','Nguyễn Hoàng Khánh Duy',NULL,'male',NULL,'admin');
-INSERT INTO "account"("email","password","phone","fullname","birthday","gender","avatar","account_type") VALUES('user1@gmail.com','04f8996da763b7a969b1028ee3007569eaf3a635486ddab211d512c85b9df8fb','0987654324','User 1',NULL,'female',NULL,'user');
-INSERT INTO "account"("email","password","phone","fullname","birthday","gender","avatar","account_type") VALUES('user2@gmail.com','04f8996da763b7a969b1028ee3007569eaf3a635486ddab211d512c85b9df8fb','0987654325','User 2',NULL,'male',NULL,'user');
-INSERT INTO "account"("email","password","phone","fullname","birthday","gender","avatar","account_type") VALUES('user3@gmail.com','04f8996da763b7a969b1028ee3007569eaf3a635486ddab211d512c85b9df8fb','0987654326','User 3',NULL,'female',NULL,'user');
-INSERT INTO "account"("email","password","phone","fullname","birthday","gender","avatar","account_type") VALUES('user4@gmail.com','04f8996da763b7a969b1028ee3007569eaf3a635486ddab211d512c85b9df8fb','0987654327','User 4',NULL,'male',NULL,'user');
-INSERT INTO "account"("email","password","phone","fullname","birthday","gender","avatar","account_type") VALUES('user5@gmail.com','04f8996da763b7a969b1028ee3007569eaf3a635486ddab211d512c85b9df8fb','0987654328','User 5',NULL,'female',NULL,'user');
+INSERT INTO "account"("email","password","phone","fullname","birthday","gender","avatar","account_type") VALUES('phuc16102001@gmail.com','ODYyNCYzZjA5M2ZjNTUyMTc3NDg1YWU4YzljZDNkMDZhOGNkNGE5YTcyMTE3ODVkYTNkNGQwNTViYmU3MWZkYmU3YjJh','0707953475','Đỗ Vương Phúc','2001-10-16','male',NULL,'admin');
+INSERT INTO "account"("email","password","phone","fullname","birthday","gender","avatar","account_type") VALUES('thanhhoang4869@gmail.com','MGE5MiY4NTQ5OWY5M2ZlN2I3YzEyOGJmYzE3MzljMTg1N2RlOWQxNzhiYjFiNWM0YjUwNDhhZDE0NzFhYTBhMGViM2Nj','0933442607','Hoàng Như Thanh','2001-07-26','female',NULL,'admin');
+INSERT INTO "account"("email","password","phone","fullname","birthday","gender","avatar","account_type") VALUES('nnhatdu@gmail.com','MmJlZSZkZDhlYjY0MjQ3MGYwODIwMWJjNWQ5MWQyMDM0MDA0MjliYmQ2YWFkZTczMzQ5YmFiNjI0MTZiMTI3YzI3ODVi','0987654321','Ngô Nhật Du',NULL,'female',NULL,'admin');
+INSERT INTO "account"("email","password","phone","fullname","birthday","gender","avatar","account_type") VALUES('longmydu@gmail.com','ZGM5NyZmZDM1MzgyMTFkN2U3MzJhZGYwMWQzMWM5MjQ1NzY0ZDBiOTE5OTQ1Nzg3ZDNlMDBmMDY3YTdhNWQwYjNjNGJl','0987654322','Long Mỹ Du',NULL,'female',NULL,'admin');
+INSERT INTO "account"("email","password","phone","fullname","birthday","gender","avatar","account_type") VALUES('nhkduy201@gmail.com','Y2JiYyZiMzBkODNmYmQ0OTcxNzFhZTcyMTZiNGE5ZWQ2NmVhN2NjODg3NTUyZmRjZmVjMTA1M2FlMDIwOWY3Nzg2MTJk','0987654323','Nguyễn Hoàng Khánh Duy',NULL,'male',NULL,'admin');
+INSERT INTO "account"("email","password","phone","fullname","birthday","gender","avatar","account_type") VALUES('user1@gmail.com','NGQyNiYyZjNhMjIxYjEwNzRkYWUzZGRkOGQ0NmIyN2I3ZmRiZDgwNWU1ZjhjZTMyMmE3NTExZGQ0NzFlMDk5MmVmMjdi','0987654324','User 1',NULL,'female',NULL,'user');
+INSERT INTO "account"("email","password","phone","fullname","birthday","gender","avatar","account_type") VALUES('user2@gmail.com','NTk2NCY1N2ZjYjY4OTVmNzYwZTQ3OWY0ZGVhNzJkM2Y4ZWZkMjY1NWU0Yjk3M2I2ZGZmZTY5YTNkMGMzMDhiNTM0ZDJm','0987654325','User 2',NULL,'male',NULL,'user');
+INSERT INTO "account"("email","password","phone","fullname","birthday","gender","avatar","account_type") VALUES('user3@gmail.com','NWRhNSYyZmM2MGZlNTQ1ZDk1Y2Q1YzY0MjI3ZTMwOGUzZjExNDQ0Y2NmOTUzMTZjMGZjMWNiZjI0NjhiMmQyNDg2NGEy','0987654326','User 3',NULL,'female',NULL,'user');
+INSERT INTO "account"("email","password","phone","fullname","birthday","gender","avatar","account_type") VALUES('user4@gmail.com','MDRlMSYyMGI4YzRiMmVhMThiMmNhNWY3YmUyMGE1MzhjYjMzZWU2MTk0OTNkZjkzMjk3MzFjMzg3MzA2MmY4NmEzNTI5','0987654327','User 4',NULL,'male',NULL,'user');
+INSERT INTO "account"("email","password","phone","fullname","birthday","gender","avatar","account_type") VALUES('user5@gmail.com','MjUzYSYwYTkwYTFhNDhhZjRiOGYxODEwZWQ2YWM3ZGVkNjc2NzZkOTg1ZTI4ZmI0ZjE5MTFjZWM1MTBlNmRmZmVjM2Ey','0987654328','User 5',NULL,'female',NULL,'user');
 
 INSERT INTO "payment"("provider") VALUES('paypal');
 INSERT INTO "payment"("provider") VALUES('momo');

--- a/src/backend/database/data/district.csv
+++ b/src/backend/database/data/district.csv
@@ -1,0 +1,705 @@
+1,Quận Ba Đình,1
+2,Quận Hoàn Kiếm,1
+3,Quận Tây Hồ,1
+4,Quận Long Biên,1
+5,Quận Cầu Giấy,1
+6,Quận Đống Đa,1
+7,Quận Hai Bà Trưng,1
+8,Quận Hoàng Mai,1
+9,Quận Thanh Xuân,1
+16,Huyện Sóc Sơn,1
+17,Huyện Đông Anh,1
+18,Huyện Gia Lâm,1
+19,Quận Nam Từ Liêm,1
+20,Huyện Thanh Trì,1
+21,Quận Bắc Từ Liêm,1
+250,Huyện Mê Linh,1
+268,Quận Hà Đông,1
+269,Thị xã Sơn Tây,1
+271,Huyện Ba Vì,1
+272,Huyện Phúc Thọ,1
+273,Huyện Đan Phượng,1
+274,Huyện Hoài Đức,1
+275,Huyện Quốc Oai,1
+276,Huyện Thạch Thất,1
+277,Huyện Chương Mỹ,1
+278,Huyện Thanh Oai,1
+279,Huyện Thường Tín,1
+280,Huyện Phú Xuyên,1
+281,Huyện Ứng Hòa,1
+282,Huyện Mỹ Đức,1
+24,Thành phố Hà Giang,2
+26,Huyện Đồng Văn,2
+27,Huyện Mèo Vạc,2
+28,Huyện Yên Minh,2
+29,Huyện Quản Bạ,2
+30,Huyện Vị Xuyên,2
+31,Huyện Bắc Mê,2
+32,Huyện Hoàng Su Phì,2
+33,Huyện Xín Mần,2
+34,Huyện Bắc Quang,2
+35,Huyện Quang Bình,2
+40,Thành phố Cao Bằng,4
+42,Huyện Bảo Lâm,4
+43,Huyện Bảo Lạc,4
+45,Huyện Hà Quảng,4
+47,Huyện Trùng Khánh,4
+48,Huyện Hạ Lang,4
+49,Huyện Quảng Hòa,4
+51,Huyện Hoà An,4
+52,Huyện Nguyên Bình,4
+53,Huyện Thạch An,4
+58,Thành Phố Bắc Kạn,6
+60,Huyện Pác Nặm,6
+61,Huyện Ba Bể,6
+62,Huyện Ngân Sơn,6
+63,Huyện Bạch Thông,6
+64,Huyện Chợ Đồn,6
+65,Huyện Chợ Mới,6
+66,Huyện Na Rì,6
+70,Thành phố Tuyên Quang,8
+71,Huyện Lâm Bình,8
+72,Huyện Na Hang,8
+73,Huyện Chiêm Hóa,8
+74,Huyện Hàm Yên,8
+75,Huyện Yên Sơn,8
+76,Huyện Sơn Dương,8
+80,Thành phố Lào Cai,10
+82,Huyện Bát Xát,10
+83,Huyện Mường Khương,10
+84,Huyện Si Ma Cai,10
+85,Huyện Bắc Hà,10
+86,Huyện Bảo Thắng,10
+87,Huyện Bảo Yên,10
+88,Thị xã Sa Pa,10
+89,Huyện Văn Bàn,10
+94,Thành phố Điện Biên Phủ,11
+95,Thị Xã Mường Lay,11
+96,Huyện Mường Nhé,11
+97,Huyện Mường Chà,11
+98,Huyện Tủa Chùa,11
+99,Huyện Tuần Giáo,11
+100,Huyện Điện Biên,11
+101,Huyện Điện Biên Đông,11
+102,Huyện Mường Ảng,11
+103,Huyện Nậm Pồ,11
+105,Thành phố Lai Châu,12
+106,Huyện Tam Đường,12
+107,Huyện Mường Tè,12
+108,Huyện Sìn Hồ,12
+109,Huyện Phong Thổ,12
+110,Huyện Than Uyên,12
+111,Huyện Tân Uyên,12
+112,Huyện Nậm Nhùn,12
+116,Thành phố Sơn La,14
+118,Huyện Quỳnh Nhai,14
+119,Huyện Thuận Châu,14
+120,Huyện Mường La,14
+121,Huyện Bắc Yên,14
+122,Huyện Phù Yên,14
+123,Huyện Mộc Châu,14
+124,Huyện Yên Châu,14
+125,Huyện Mai Sơn,14
+126,Huyện Sông Mã,14
+127,Huyện Sốp Cộp,14
+128,Huyện Vân Hồ,14
+132,Thành phố Yên Bái,15
+133,Thị xã Nghĩa Lộ,15
+135,Huyện Lục Yên,15
+136,Huyện Văn Yên,15
+137,Huyện Mù Căng Chải,15
+138,Huyện Trấn Yên,15
+139,Huyện Trạm Tấu,15
+140,Huyện Văn Chấn,15
+141,Huyện Yên Bình,15
+148,Thành phố Hòa Bình,17
+150,Huyện Đà Bắc,17
+152,Huyện Lương Sơn,17
+153,Huyện Kim Bôi,17
+154,Huyện Cao Phong,17
+155,Huyện Tân Lạc,17
+156,Huyện Mai Châu,17
+157,Huyện Lạc Sơn,17
+158,Huyện Yên Thủy,17
+159,Huyện Lạc Thủy,17
+164,Thành phố Thái Nguyên,19
+165,Thành phố Sông Công,19
+167,Huyện Định Hóa,19
+168,Huyện Phú Lương,19
+169,Huyện Đồng Hỷ,19
+170,Huyện Võ Nhai,19
+171,Huyện Đại Từ,19
+172,Thành phố Phổ Yên,19
+173,Huyện Phú Bình,19
+178,Thành phố Lạng Sơn,20
+180,Huyện Tràng Định,20
+181,Huyện Bình Gia,20
+182,Huyện Văn Lãng,20
+183,Huyện Cao Lộc,20
+184,Huyện Văn Quan,20
+185,Huyện Bắc Sơn,20
+186,Huyện Hữu Lũng,20
+187,Huyện Chi Lăng,20
+188,Huyện Lộc Bình,20
+189,Huyện Đình Lập,20
+193,Thành phố Hạ Long,22
+194,Thành phố Móng Cái,22
+195,Thành phố Cẩm Phả,22
+196,Thành phố Uông Bí,22
+198,Huyện Bình Liêu,22
+199,Huyện Tiên Yên,22
+200,Huyện Đầm Hà,22
+201,Huyện Hải Hà,22
+202,Huyện Ba Chẽ,22
+203,Huyện Vân Đồn,22
+205,Thị xã Đông Triều,22
+206,Thị xã Quảng Yên,22
+207,Huyện Cô Tô,22
+213,Thành phố Bắc Giang,24
+215,Huyện Yên Thế,24
+216,Huyện Tân Yên,24
+217,Huyện Lạng Giang,24
+218,Huyện Lục Nam,24
+219,Huyện Lục Ngạn,24
+220,Huyện Sơn Động,24
+221,Huyện Yên Dũng,24
+222,Huyện Việt Yên,24
+223,Huyện Hiệp Hòa,24
+227,Thành phố Việt Trì,25
+228,Thị xã Phú Thọ,25
+230,Huyện Đoan Hùng,25
+231,Huyện Hạ Hoà,25
+232,Huyện Thanh Ba,25
+233,Huyện Phù Ninh,25
+234,Huyện Yên Lập,25
+235,Huyện Cẩm Khê,25
+236,Huyện Tam Nông,25
+237,Huyện Lâm Thao,25
+238,Huyện Thanh Sơn,25
+239,Huyện Thanh Thuỷ,25
+240,Huyện Tân Sơn,25
+243,Thành phố Vĩnh Yên,26
+244,Thành phố Phúc Yên,26
+246,Huyện Lập Thạch,26
+247,Huyện Tam Dương,26
+248,Huyện Tam Đảo,26
+249,Huyện Bình Xuyên,26
+251,Huyện Yên Lạc,26
+252,Huyện Vĩnh Tường,26
+253,Huyện Sông Lô,26
+256,Thành phố Bắc Ninh,27
+258,Huyện Yên Phong,27
+259,Huyện Quế Võ,27
+260,Huyện Tiên Du,27
+261,Thành phố Từ Sơn,27
+262,Huyện Thuận Thành,27
+263,Huyện Gia Bình,27
+264,Huyện Lương Tài,27
+288,Thành phố Hải Dương,30
+290,Thành phố Chí Linh,30
+291,Huyện Nam Sách,30
+292,Thị xã Kinh Môn,30
+293,Huyện Kim Thành,30
+294,Huyện Thanh Hà,30
+295,Huyện Cẩm Giàng,30
+296,Huyện Bình Giang,30
+297,Huyện Gia Lộc,30
+298,Huyện Tứ Kỳ,30
+299,Huyện Ninh Giang,30
+300,Huyện Thanh Miện,30
+303,Quận Hồng Bàng,31
+304,Quận Ngô Quyền,31
+305,Quận Lê Chân,31
+306,Quận Hải An,31
+307,Quận Kiến An,31
+308,Quận Đồ Sơn,31
+309,Quận Dương Kinh,31
+311,Huyện Thuỷ Nguyên,31
+312,Huyện An Dương,31
+313,Huyện An Lão,31
+314,Huyện Kiến Thuỵ,31
+315,Huyện Tiên Lãng,31
+316,Huyện Vĩnh Bảo,31
+317,Huyện Cát Hải,31
+318,Huyện Bạch Long Vĩ,31
+323,Thành phố Hưng Yên,33
+325,Huyện Văn Lâm,33
+326,Huyện Văn Giang,33
+327,Huyện Yên Mỹ,33
+328,Thị xã Mỹ Hào,33
+329,Huyện Ân Thi,33
+330,Huyện Khoái Châu,33
+331,Huyện Kim Động,33
+332,Huyện Tiên Lữ,33
+333,Huyện Phù Cừ,33
+336,Thành phố Thái Bình,34
+338,Huyện Quỳnh Phụ,34
+339,Huyện Hưng Hà,34
+340,Huyện Đông Hưng,34
+341,Huyện Thái Thụy,34
+342,Huyện Tiền Hải,34
+343,Huyện Kiến Xương,34
+344,Huyện Vũ Thư,34
+347,Thành phố Phủ Lý,35
+349,Thị xã Duy Tiên,35
+350,Huyện Kim Bảng,35
+351,Huyện Thanh Liêm,35
+352,Huyện Bình Lục,35
+353,Huyện Lý Nhân,35
+356,Thành phố Nam Định,36
+358,Huyện Mỹ Lộc,36
+359,Huyện Vụ Bản,36
+360,Huyện Ý Yên,36
+361,Huyện Nghĩa Hưng,36
+362,Huyện Nam Trực,36
+363,Huyện Trực Ninh,36
+364,Huyện Xuân Trường,36
+365,Huyện Giao Thủy,36
+366,Huyện Hải Hậu,36
+369,Thành phố Ninh Bình,37
+370,Thành phố Tam Điệp,37
+372,Huyện Nho Quan,37
+373,Huyện Gia Viễn,37
+374,Huyện Hoa Lư,37
+375,Huyện Yên Khánh,37
+376,Huyện Kim Sơn,37
+377,Huyện Yên Mô,37
+380,Thành phố Thanh Hóa,38
+381,Thị xã Bỉm Sơn,38
+382,Thành phố Sầm Sơn,38
+384,Huyện Mường Lát,38
+385,Huyện Quan Hóa,38
+386,Huyện Bá Thước,38
+387,Huyện Quan Sơn,38
+388,Huyện Lang Chánh,38
+389,Huyện Ngọc Lặc,38
+390,Huyện Cẩm Thủy,38
+391,Huyện Thạch Thành,38
+392,Huyện Hà Trung,38
+393,Huyện Vĩnh Lộc,38
+394,Huyện Yên Định,38
+395,Huyện Thọ Xuân,38
+396,Huyện Thường Xuân,38
+397,Huyện Triệu Sơn,38
+398,Huyện Thiệu Hóa,38
+399,Huyện Hoằng Hóa,38
+400,Huyện Hậu Lộc,38
+401,Huyện Nga Sơn,38
+402,Huyện Như Xuân,38
+403,Huyện Như Thanh,38
+404,Huyện Nông Cống,38
+405,Huyện Đông Sơn,38
+406,Huyện Quảng Xương,38
+407,Thị xã Nghi Sơn,38
+412,Thành phố Vinh,40
+413,Thị xã Cửa Lò,40
+414,Thị xã Thái Hoà,40
+415,Huyện Quế Phong,40
+416,Huyện Quỳ Châu,40
+417,Huyện Kỳ Sơn,40
+418,Huyện Tương Dương,40
+419,Huyện Nghĩa Đàn,40
+420,Huyện Quỳ Hợp,40
+421,Huyện Quỳnh Lưu,40
+422,Huyện Con Cuông,40
+423,Huyện Tân Kỳ,40
+424,Huyện Anh Sơn,40
+425,Huyện Diễn Châu,40
+426,Huyện Yên Thành,40
+427,Huyện Đô Lương,40
+428,Huyện Thanh Chương,40
+429,Huyện Nghi Lộc,40
+430,Huyện Nam Đàn,40
+431,Huyện Hưng Nguyên,40
+432,Thị xã Hoàng Mai,40
+436,Thành phố Hà Tĩnh,42
+437,Thị xã Hồng Lĩnh,42
+439,Huyện Hương Sơn,42
+440,Huyện Đức Thọ,42
+441,Huyện Vũ Quang,42
+442,Huyện Nghi Xuân,42
+443,Huyện Can Lộc,42
+444,Huyện Hương Khê,42
+445,Huyện Thạch Hà,42
+446,Huyện Cẩm Xuyên,42
+447,Huyện Kỳ Anh,42
+448,Huyện Lộc Hà,42
+449,Thị xã Kỳ Anh,42
+450,Thành Phố Đồng Hới,44
+452,Huyện Minh Hóa,44
+453,Huyện Tuyên Hóa,44
+454,Huyện Quảng Trạch,44
+455,Huyện Bố Trạch,44
+456,Huyện Quảng Ninh,44
+457,Huyện Lệ Thủy,44
+458,Thị xã Ba Đồn,44
+461,Thành phố Đông Hà,45
+462,Thị xã Quảng Trị,45
+464,Huyện Vĩnh Linh,45
+465,Huyện Hướng Hóa,45
+466,Huyện Gio Linh,45
+467,Huyện Đa Krông,45
+468,Huyện Cam Lộ,45
+469,Huyện Triệu Phong,45
+470,Huyện Hải Lăng,45
+471,Huyện Cồn Cỏ,45
+474,Thành phố Huế,46
+476,Huyện Phong Điền,46
+477,Huyện Quảng Điền,46
+478,Huyện Phú Vang,46
+479,Thị xã Hương Thủy,46
+480,Thị xã Hương Trà,46
+481,Huyện A Lưới,46
+482,Huyện Phú Lộc,46
+483,Huyện Nam Đông,46
+490,Quận Liên Chiểu,48
+491,Quận Thanh Khê,48
+492,Quận Hải Châu,48
+493,Quận Sơn Trà,48
+494,Quận Ngũ Hành Sơn,48
+495,Quận Cẩm Lệ,48
+497,Huyện Hòa Vang,48
+498,Huyện Hoàng Sa,48
+502,Thành phố Tam Kỳ,49
+503,Thành phố Hội An,49
+504,Huyện Tây Giang,49
+505,Huyện Đông Giang,49
+506,Huyện Đại Lộc,49
+507,Thị xã Điện Bàn,49
+508,Huyện Duy Xuyên,49
+509,Huyện Quế Sơn,49
+510,Huyện Nam Giang,49
+511,Huyện Phước Sơn,49
+512,Huyện Hiệp Đức,49
+513,Huyện Thăng Bình,49
+514,Huyện Tiên Phước,49
+515,Huyện Bắc Trà My,49
+516,Huyện Nam Trà My,49
+517,Huyện Núi Thành,49
+518,Huyện Phú Ninh,49
+519,Huyện Nông Sơn,49
+522,Thành phố Quảng Ngãi,51
+524,Huyện Bình Sơn,51
+525,Huyện Trà Bồng,51
+527,Huyện Sơn Tịnh,51
+528,Huyện Tư Nghĩa,51
+529,Huyện Sơn Hà,51
+530,Huyện Sơn Tây,51
+531,Huyện Minh Long,51
+532,Huyện Nghĩa Hành,51
+533,Huyện Mộ Đức,51
+534,Thị xã Đức Phổ,51
+535,Huyện Ba Tơ,51
+536,Huyện Lý Sơn,51
+540,Thành phố Quy Nhơn,52
+542,Huyện An Lão,52
+543,Thị xã Hoài Nhơn,52
+544,Huyện Hoài Ân,52
+545,Huyện Phù Mỹ,52
+546,Huyện Vĩnh Thạnh,52
+547,Huyện Tây Sơn,52
+548,Huyện Phù Cát,52
+549,Thị xã An Nhơn,52
+550,Huyện Tuy Phước,52
+551,Huyện Vân Canh,52
+555,Thành phố Tuy Hoà,54
+557,Thị xã Sông Cầu,54
+558,Huyện Đồng Xuân,54
+559,Huyện Tuy An,54
+560,Huyện Sơn Hòa,54
+561,Huyện Sông Hinh,54
+562,Huyện Tây Hoà,54
+563,Huyện Phú Hoà,54
+564,Thị xã Đông Hòa,54
+568,Thành phố Nha Trang,56
+569,Thành phố Cam Ranh,56
+570,Huyện Cam Lâm,56
+571,Huyện Vạn Ninh,56
+572,Thị xã Ninh Hòa,56
+573,Huyện Khánh Vĩnh,56
+574,Huyện Diên Khánh,56
+575,Huyện Khánh Sơn,56
+576,Huyện Trường Sa,56
+582,Thành phố Phan Rang-Tháp Chàm,58
+584,Huyện Bác Ái,58
+585,Huyện Ninh Sơn,58
+586,Huyện Ninh Hải,58
+587,Huyện Ninh Phước,58
+588,Huyện Thuận Bắc,58
+589,Huyện Thuận Nam,58
+593,Thành phố Phan Thiết,60
+594,Thị xã La Gi,60
+595,Huyện Tuy Phong,60
+596,Huyện Bắc Bình,60
+597,Huyện Hàm Thuận Bắc,60
+598,Huyện Hàm Thuận Nam,60
+599,Huyện Tánh Linh,60
+600,Huyện Đức Linh,60
+601,Huyện Hàm Tân,60
+602,Huyện Phú Quí,60
+608,Thành phố Kon Tum,62
+610,Huyện Đắk Glei,62
+611,Huyện Ngọc Hồi,62
+612,Huyện Đắk Tô,62
+613,Huyện Kon Plông,62
+614,Huyện Kon Rẫy,62
+615,Huyện Đắk Hà,62
+616,Huyện Sa Thầy,62
+617,Huyện Tu Mơ Rông,62
+618,Huyện Ia H' Drai,62
+622,Thành phố Pleiku,64
+623,Thị xã An Khê,64
+624,Thị xã Ayun Pa,64
+625,Huyện KBang,64
+626,Huyện Đăk Đoa,64
+627,Huyện Chư Păh,64
+628,Huyện Ia Grai,64
+629,Huyện Mang Yang,64
+630,Huyện Kông Chro,64
+631,Huyện Đức Cơ,64
+632,Huyện Chư Prông,64
+633,Huyện Chư Sê,64
+634,Huyện Đăk Pơ,64
+635,Huyện Ia Pa,64
+637,Huyện Krông Pa,64
+638,Huyện Phú Thiện,64
+639,Huyện Chư Pưh,64
+643,Thành phố Buôn Ma Thuột,66
+644,Thị Xã Buôn Hồ,66
+645,Huyện Ea H'leo,66
+646,Huyện Ea Súp,66
+647,Huyện Buôn Đôn,66
+648,Huyện Cư M'gar,66
+649,Huyện Krông Búk,66
+650,Huyện Krông Năng,66
+651,Huyện Ea Kar,66
+652,Huyện M'Đrắk,66
+653,Huyện Krông Bông,66
+654,Huyện Krông Pắc,66
+655,Huyện Krông A Na,66
+656,Huyện Lắk,66
+657,Huyện Cư Kuin,66
+660,Thành phố Gia Nghĩa,67
+661,Huyện Đăk Glong,67
+662,Huyện Cư Jút,67
+663,Huyện Đắk Mil,67
+664,Huyện Krông Nô,67
+665,Huyện Đắk Song,67
+666,Huyện Đắk R'Lấp,67
+667,Huyện Tuy Đức,67
+672,Thành phố Đà Lạt,68
+673,Thành phố Bảo Lộc,68
+674,Huyện Đam Rông,68
+675,Huyện Lạc Dương,68
+676,Huyện Lâm Hà,68
+677,Huyện Đơn Dương,68
+678,Huyện Đức Trọng,68
+679,Huyện Di Linh,68
+680,Huyện Bảo Lâm,68
+681,Huyện Đạ Huoai,68
+682,Huyện Đạ Tẻh,68
+683,Huyện Cát Tiên,68
+688,Thị xã Phước Long,70
+689,Thành phố Đồng Xoài,70
+690,Thị xã Bình Long,70
+691,Huyện Bù Gia Mập,70
+692,Huyện Lộc Ninh,70
+693,Huyện Bù Đốp,70
+694,Huyện Hớn Quản,70
+695,Huyện Đồng Phú,70
+696,Huyện Bù Đăng,70
+697,Huyện Chơn Thành,70
+698,Huyện Phú Riềng,70
+703,Thành phố Tây Ninh,72
+705,Huyện Tân Biên,72
+706,Huyện Tân Châu,72
+707,Huyện Dương Minh Châu,72
+708,Huyện Châu Thành,72
+709,Thị xã Hòa Thành,72
+710,Huyện Gò Dầu,72
+711,Huyện Bến Cầu,72
+712,Thị xã Trảng Bàng,72
+718,Thành phố Thủ Dầu Một,74
+719,Huyện Bàu Bàng,74
+720,Huyện Dầu Tiếng,74
+721,Thị xã Bến Cát,74
+722,Huyện Phú Giáo,74
+723,Thị xã Tân Uyên,74
+724,Thành phố Dĩ An,74
+725,Thành phố Thuận An,74
+726,Huyện Bắc Tân Uyên,74
+731,Thành phố Biên Hòa,75
+732,Thành phố Long Khánh,75
+734,Huyện Tân Phú,75
+735,Huyện Vĩnh Cửu,75
+736,Huyện Định Quán,75
+737,Huyện Trảng Bom,75
+738,Huyện Thống Nhất,75
+739,Huyện Cẩm Mỹ,75
+740,Huyện Long Thành,75
+741,Huyện Xuân Lộc,75
+742,Huyện Nhơn Trạch,75
+747,Thành phố Vũng Tàu,77
+748,Thành phố Bà Rịa,77
+750,Huyện Châu Đức,77
+751,Huyện Xuyên Mộc,77
+752,Huyện Long Điền,77
+753,Huyện Đất Đỏ,77
+754,Thị xã Phú Mỹ,77
+755,Huyện Côn Đảo,77
+760,Quận 1,79
+761,Quận 12,79
+764,Quận Gò Vấp,79
+765,Quận Bình Thạnh,79
+766,Quận Tân Bình,79
+767,Quận Tân Phú,79
+768,Quận Phú Nhuận,79
+769,Thành phố Thủ Đức,79
+770,Quận 3,79
+771,Quận 10,79
+772,Quận 11,79
+773,Quận 4,79
+774,Quận 5,79
+775,Quận 6,79
+776,Quận 8,79
+777,Quận Bình Tân,79
+778,Quận 7,79
+783,Huyện Củ Chi,79
+784,Huyện Hóc Môn,79
+785,Huyện Bình Chánh,79
+786,Huyện Nhà Bè,79
+787,Huyện Cần Giờ,79
+794,Thành phố Tân An,80
+795,Thị xã Kiến Tường,80
+796,Huyện Tân Hưng,80
+797,Huyện Vĩnh Hưng,80
+798,Huyện Mộc Hóa,80
+799,Huyện Tân Thạnh,80
+800,Huyện Thạnh Hóa,80
+801,Huyện Đức Huệ,80
+802,Huyện Đức Hòa,80
+803,Huyện Bến Lức,80
+804,Huyện Thủ Thừa,80
+805,Huyện Tân Trụ,80
+806,Huyện Cần Đước,80
+807,Huyện Cần Giuộc,80
+808,Huyện Châu Thành,80
+815,Thành phố Mỹ Tho,82
+816,Thị xã Gò Công,82
+817,Thị xã Cai Lậy,82
+818,Huyện Tân Phước,82
+819,Huyện Cái Bè,82
+820,Huyện Cai Lậy,82
+821,Huyện Châu Thành,82
+822,Huyện Chợ Gạo,82
+823,Huyện Gò Công Tây,82
+824,Huyện Gò Công Đông,82
+825,Huyện Tân Phú Đông,82
+829,Thành phố Bến Tre,83
+831,Huyện Châu Thành,83
+832,Huyện Chợ Lách,83
+833,Huyện Mỏ Cày Nam,83
+834,Huyện Giồng Trôm,83
+835,Huyện Bình Đại,83
+836,Huyện Ba Tri,83
+837,Huyện Thạnh Phú,83
+838,Huyện Mỏ Cày Bắc,83
+842,Thành phố Trà Vinh,84
+844,Huyện Càng Long,84
+845,Huyện Cầu Kè,84
+846,Huyện Tiểu Cần,84
+847,Huyện Châu Thành,84
+848,Huyện Cầu Ngang,84
+849,Huyện Trà Cú,84
+850,Huyện Duyên Hải,84
+851,Thị xã Duyên Hải,84
+855,Thành phố Vĩnh Long,86
+857,Huyện Long Hồ,86
+858,Huyện Mang Thít,86
+859,Huyện  Vũng Liêm,86
+860,Huyện Tam Bình,86
+861,Thị xã Bình Minh,86
+862,Huyện Trà Ôn,86
+863,Huyện Bình Tân,86
+866,Thành phố Cao Lãnh,87
+867,Thành phố Sa Đéc,87
+868,Thành phố Hồng Ngự,87
+869,Huyện Tân Hồng,87
+870,Huyện Hồng Ngự,87
+871,Huyện Tam Nông,87
+872,Huyện Tháp Mười,87
+873,Huyện Cao Lãnh,87
+874,Huyện Thanh Bình,87
+875,Huyện Lấp Vò,87
+876,Huyện Lai Vung,87
+877,Huyện Châu Thành,87
+883,Thành phố Long Xuyên,89
+884,Thành phố Châu Đốc,89
+886,Huyện An Phú,89
+887,Thị xã Tân Châu,89
+888,Huyện Phú Tân,89
+889,Huyện Châu Phú,89
+890,Huyện Tịnh Biên,89
+891,Huyện Tri Tôn,89
+892,Huyện Châu Thành,89
+893,Huyện Chợ Mới,89
+894,Huyện Thoại Sơn,89
+899,Thành phố Rạch Giá,91
+900,Thành phố Hà Tiên,91
+902,Huyện Kiên Lương,91
+903,Huyện Hòn Đất,91
+904,Huyện Tân Hiệp,91
+905,Huyện Châu Thành,91
+906,Huyện Giồng Riềng,91
+907,Huyện Gò Quao,91
+908,Huyện An Biên,91
+909,Huyện An Minh,91
+910,Huyện Vĩnh Thuận,91
+911,Thành phố Phú Quốc,91
+912,Huyện Kiên Hải,91
+913,Huyện U Minh Thượng,91
+914,Huyện Giang Thành,91
+916,Quận Ninh Kiều,92
+917,Quận Ô Môn,92
+918,Quận Bình Thuỷ,92
+919,Quận Cái Răng,92
+923,Quận Thốt Nốt,92
+924,Huyện Vĩnh Thạnh,92
+925,Huyện Cờ Đỏ,92
+926,Huyện Phong Điền,92
+927,Huyện Thới Lai,92
+930,Thành phố Vị Thanh,93
+931,Thành phố Ngã Bảy,93
+932,Huyện Châu Thành A,93
+933,Huyện Châu Thành,93
+934,Huyện Phụng Hiệp,93
+935,Huyện Vị Thuỷ,93
+936,Huyện Long Mỹ,93
+937,Thị xã Long Mỹ,93
+941,Thành phố Sóc Trăng,94
+942,Huyện Châu Thành,94
+943,Huyện Kế Sách,94
+944,Huyện Mỹ Tú,94
+945,Huyện Cù Lao Dung,94
+946,Huyện Long Phú,94
+947,Huyện Mỹ Xuyên,94
+948,Thị xã Ngã Năm,94
+949,Huyện Thạnh Trị,94
+950,Thị xã Vĩnh Châu,94
+951,Huyện Trần Đề,94
+954,Thành phố Bạc Liêu,95
+956,Huyện Hồng Dân,95
+957,Huyện Phước Long,95
+958,Huyện Vĩnh Lợi,95
+959,Thị xã Giá Rai,95
+960,Huyện Đông Hải,95
+961,Huyện Hoà Bình,95
+964,Thành phố Cà Mau,96
+966,Huyện U Minh,96
+967,Huyện Thới Bình,96
+968,Huyện Trần Văn Thời,96
+969,Huyện Cái Nước,96
+970,Huyện Đầm Dơi,96
+971,Huyện Năm Căn,96
+972,Huyện Phú Tân,96
+973,Huyện Ngọc Hiển,96

--- a/src/backend/database/data/province.csv
+++ b/src/backend/database/data/province.csv
@@ -1,0 +1,63 @@
+1,Thành phố Hà Nội
+2,Tỉnh Hà Giang
+4,Tỉnh Cao Bằng
+6,Tỉnh Bắc Kạn
+8,Tỉnh Tuyên Quang
+10,Tỉnh Lào Cai
+11,Tỉnh Điện Biên
+12,Tỉnh Lai Châu
+14,Tỉnh Sơn La
+15,Tỉnh Yên Bái
+17,Tỉnh Hoà Bình
+19,Tỉnh Thái Nguyên
+20,Tỉnh Lạng Sơn
+22,Tỉnh Quảng Ninh
+24,Tỉnh Bắc Giang
+25,Tỉnh Phú Thọ
+26,Tỉnh Vĩnh Phúc
+27,Tỉnh Bắc Ninh
+30,Tỉnh Hải Dương
+31,Thành phố Hải Phòng
+33,Tỉnh Hưng Yên
+34,Tỉnh Thái Bình
+35,Tỉnh Hà Nam
+36,Tỉnh Nam Định
+37,Tỉnh Ninh Bình
+38,Tỉnh Thanh Hóa
+40,Tỉnh Nghệ An
+42,Tỉnh Hà Tĩnh
+44,Tỉnh Quảng Bình
+45,Tỉnh Quảng Trị
+46,Tỉnh Thừa Thiên Huế
+48,Thành phố Đà Nẵng
+49,Tỉnh Quảng Nam
+51,Tỉnh Quảng Ngãi
+52,Tỉnh Bình Định
+54,Tỉnh Phú Yên
+56,Tỉnh Khánh Hòa
+58,Tỉnh Ninh Thuận
+60,Tỉnh Bình Thuận
+62,Tỉnh Kon Tum
+64,Tỉnh Gia Lai
+66,Tỉnh Đắk Lắk
+67,Tỉnh Đắk Nông
+68,Tỉnh Lâm Đồng
+70,Tỉnh Bình Phước
+72,Tỉnh Tây Ninh
+74,Tỉnh Bình Dương
+75,Tỉnh Đồng Nai
+77,Tỉnh Bà Rịa - Vũng Tàu
+79,Thành phố Hồ Chí Minh
+80,Tỉnh Long An
+82,Tỉnh Tiền Giang
+83,Tỉnh Bến Tre
+84,Tỉnh Trà Vinh
+86,Tỉnh Vĩnh Long
+87,Tỉnh Đồng Tháp
+89,Tỉnh An Giang
+91,Tỉnh Kiên Giang
+92,Thành phố Cần Thơ
+93,Tỉnh Hậu Giang
+94,Tỉnh Sóc Trăng
+95,Tỉnh Bạc Liêu
+96,Tỉnh Cà Mau

--- a/src/backend/database/data/ward.csv
+++ b/src/backend/database/data/ward.csv
@@ -1,0 +1,10599 @@
+1,Phường Phúc Xá,1
+4,Phường Trúc Bạch,1
+6,Phường Vĩnh Phúc,1
+7,Phường Cống Vị,1
+8,Phường Liễu Giai,1
+10,Phường Nguyễn Trung Trực,1
+13,Phường Quán Thánh,1
+16,Phường Ngọc Hà,1
+19,Phường Điện Biên,1
+22,Phường Đội Cấn,1
+25,Phường Ngọc Khánh,1
+28,Phường Kim Mã,1
+31,Phường Giảng Võ,1
+34,Phường Thành Công,1
+37,Phường Phúc Tân,2
+40,Phường Đồng Xuân,2
+43,Phường Hàng Mã,2
+46,Phường Hàng Buồm,2
+49,Phường Hàng Đào,2
+52,Phường Hàng Bồ,2
+55,Phường Cửa Đông,2
+58,Phường Lý Thái Tổ,2
+61,Phường Hàng Bạc,2
+64,Phường Hàng Gai,2
+67,Phường Chương Dương,2
+70,Phường Hàng Trống,2
+73,Phường Cửa Nam,2
+76,Phường Hàng Bông,2
+79,Phường Tràng Tiền,2
+82,Phường Trần Hưng Đạo,2
+85,Phường Phan Chu Trinh,2
+88,Phường Hàng Bài,2
+91,Phường Phú Thượng,3
+94,Phường Nhật Tân,3
+97,Phường Tứ Liên,3
+100,Phường Quảng An,3
+103,Phường Xuân La,3
+106,Phường Yên Phụ,3
+109,Phường Bưởi,3
+112,Phường Thụy Khuê,3
+115,Phường Thượng Thanh,4
+118,Phường Ngọc Thụy,4
+121,Phường Giang Biên,4
+124,Phường Đức Giang,4
+127,Phường Việt Hưng,4
+130,Phường Gia Thụy,4
+133,Phường Ngọc Lâm,4
+136,Phường Phúc Lợi,4
+139,Phường Bồ Đề,4
+142,Phường Sài Đồng,4
+145,Phường Long Biên,4
+148,Phường Thạch Bàn,4
+151,Phường Phúc Đồng,4
+154,Phường Cự Khối,4
+157,Phường Nghĩa Đô,5
+160,Phường Nghĩa Tân,5
+163,Phường Mai Dịch,5
+166,Phường Dịch Vọng,5
+167,Phường Dịch Vọng Hậu,5
+169,Phường Quan Hoa,5
+172,Phường Yên Hoà,5
+175,Phường Trung Hoà,5
+178,Phường Cát Linh,6
+181,Phường Văn Miếu,6
+184,Phường Quốc Tử Giám,6
+187,Phường Láng Thượng,6
+190,Phường Ô Chợ Dừa,6
+193,Phường Văn Chương,6
+196,Phường Hàng Bột,6
+199,Phường Láng Hạ,6
+202,Phường Khâm Thiên,6
+205,Phường Thổ Quan,6
+208,Phường Nam Đồng,6
+211,Phường Trung Phụng,6
+214,Phường Quang Trung,6
+217,Phường Trung Liệt,6
+220,Phường Phương Liên,6
+223,Phường Thịnh Quang,6
+226,Phường Trung Tự,6
+229,Phường Kim Liên,6
+232,Phường Phương Mai,6
+235,Phường Ngã Tư Sở,6
+238,Phường Khương Thượng,6
+241,Phường Nguyễn Du,7
+244,Phường Bạch Đằng,7
+247,Phường Phạm Đình Hổ,7
+256,Phường Lê Đại Hành,7
+259,Phường Đồng Nhân,7
+262,Phường Phố Huế,7
+265,Phường Đống Mác,7
+268,Phường Thanh Lương,7
+271,Phường Thanh Nhàn,7
+274,Phường Cầu Dền,7
+277,Phường Bách Khoa,7
+280,Phường Đồng Tâm,7
+283,Phường Vĩnh Tuy,7
+286,Phường Bạch Mai,7
+289,Phường Quỳnh Mai,7
+292,Phường Quỳnh Lôi,7
+295,Phường Minh Khai,7
+298,Phường Trương Định,7
+301,Phường Thanh Trì,8
+304,Phường Vĩnh Hưng,8
+307,Phường Định Công,8
+310,Phường Mai Động,8
+313,Phường Tương Mai,8
+316,Phường Đại Kim,8
+319,Phường Tân Mai,8
+322,Phường Hoàng Văn Thụ,8
+325,Phường Giáp Bát,8
+328,Phường Lĩnh Nam,8
+331,Phường Thịnh Liệt,8
+334,Phường Trần Phú,8
+337,Phường Hoàng Liệt,8
+340,Phường Yên Sở,8
+343,Phường Nhân Chính,9
+346,Phường Thượng Đình,9
+349,Phường Khương Trung,9
+352,Phường Khương Mai,9
+355,Phường Thanh Xuân Trung,9
+358,Phường Phương Liệt,9
+361,Phường Hạ Đình,9
+364,Phường Khương Đình,9
+367,Phường Thanh Xuân Bắc,9
+370,Phường Thanh Xuân Nam,9
+373,Phường Kim Giang,9
+376,Thị trấn Sóc Sơn,16
+379,Xã Bắc Sơn,16
+382,Xã Minh Trí,16
+385,Xã Hồng Kỳ,16
+388,Xã Nam Sơn,16
+391,Xã Trung Giã,16
+394,Xã Tân Hưng,16
+397,Xã Minh Phú,16
+400,Xã Phù Linh,16
+403,Xã Bắc Phú,16
+406,Xã Tân Minh,16
+409,Xã Quang Tiến,16
+412,Xã Hiền Ninh,16
+415,Xã Tân Dân,16
+418,Xã Tiên Dược,16
+421,Xã Việt Long,16
+424,Xã Xuân Giang,16
+427,Xã Mai Đình,16
+430,Xã Đức Hoà,16
+433,Xã Thanh Xuân,16
+436,Xã Đông Xuân,16
+439,Xã Kim Lũ,16
+442,Xã Phú Cường,16
+445,Xã Phú Minh,16
+448,Xã Phù Lỗ,16
+451,Xã Xuân Thu,16
+454,Thị trấn Đông Anh,17
+457,Xã Xuân Nộn,17
+460,Xã Thuỵ Lâm,17
+463,Xã Bắc Hồng,17
+466,Xã Nguyên Khê,17
+469,Xã Nam Hồng,17
+472,Xã Tiên Dương,17
+475,Xã Vân Hà,17
+478,Xã Uy Nỗ,17
+481,Xã Vân Nội,17
+484,Xã Liên Hà,17
+487,Xã Việt Hùng,17
+490,Xã Kim Nỗ,17
+493,Xã Kim Chung,17
+496,Xã Dục Tú,17
+499,Xã Đại Mạch,17
+502,Xã Vĩnh Ngọc,17
+505,Xã Cổ Loa,17
+508,Xã Hải Bối,17
+511,Xã Xuân Canh,17
+514,Xã Võng La,17
+517,Xã Tàm Xá,17
+520,Xã Mai Lâm,17
+523,Xã Đông Hội,17
+526,Thị trấn Yên Viên,18
+529,Xã Yên Thường,18
+532,Xã Yên Viên,18
+535,Xã Ninh Hiệp,18
+538,Xã Đình Xuyên,18
+541,Xã Dương Hà,18
+544,Xã Phù Đổng,18
+547,Xã Trung Mầu,18
+550,Xã Lệ Chi,18
+553,Xã Cổ Bi,18
+556,Xã Đặng Xá,18
+559,Xã Phú Thị,18
+562,Xã Kim Sơn,18
+565,Thị trấn Trâu Quỳ,18
+568,Xã Dương Quang,18
+571,Xã Dương Xá,18
+574,Xã Đông Dư,18
+577,Xã Đa Tốn,18
+580,Xã Kiêu Kỵ,18
+583,Xã Bát Tràng,18
+586,Xã Kim Lan,18
+589,Xã Văn Đức,18
+592,Phường Cầu Diễn,19
+622,Phường Xuân Phương,19
+623,Phường Phương Canh,19
+625,Phường Mỹ Đình 1,19
+626,Phường Mỹ Đình 2,19
+628,Phường Tây Mỗ,19
+631,Phường Mễ Trì,19
+632,Phường Phú Đô,19
+634,Phường Đại Mỗ,19
+637,Phường Trung Văn,19
+640,Thị trấn Văn Điển,20
+643,Xã Tân Triều,20
+646,Xã Thanh Liệt,20
+649,Xã Tả Thanh Oai,20
+652,Xã Hữu Hoà,20
+655,Xã Tam Hiệp,20
+658,Xã Tứ Hiệp,20
+661,Xã Yên Mỹ,20
+664,Xã Vĩnh Quỳnh,20
+667,Xã Ngũ Hiệp,20
+670,Xã Duyên Hà,20
+673,Xã Ngọc Hồi,20
+676,Xã Vạn Phúc,20
+679,Xã Đại áng,20
+682,Xã Liên Ninh,20
+685,Xã Đông Mỹ,20
+595,Phường Thượng Cát,21
+598,Phường Liên Mạc,21
+601,Phường Đông Ngạc,21
+602,Phường Đức Thắng,21
+604,Phường Thụy Phương,21
+607,Phường Tây Tựu,21
+610,Phường Xuân Đỉnh,21
+611,Phường Xuân Tảo,21
+613,Phường Minh Khai,21
+616,Phường Cổ Nhuế 1,21
+617,Phường Cổ Nhuế 2,21
+619,Phường Phú Diễn,21
+620,Phường Phúc Diễn,21
+8973,Thị trấn Chi Đông,250
+8974,Xã Đại Thịnh,250
+8977,Xã Kim Hoa,250
+8980,Xã Thạch Đà,250
+8983,Xã Tiến Thắng,250
+8986,Xã Tự Lập,250
+8989,Thị trấn Quang Minh,250
+8992,Xã Thanh Lâm,250
+8995,Xã Tam Đồng,250
+8998,Xã Liên Mạc,250
+9001,Xã Vạn Yên,250
+9004,Xã Chu Phan,250
+9007,Xã Tiến Thịnh,250
+9010,Xã Mê Linh,250
+9013,Xã Văn Khê,250
+9016,Xã Hoàng Kim,250
+9019,Xã Tiền Phong,250
+9022,Xã Tráng Việt,250
+9538,Phường Nguyễn Trãi,268
+9541,Phường Mộ Lao,268
+9542,Phường Văn Quán,268
+9544,Phường Vạn Phúc,268
+9547,Phường Yết Kiêu,268
+9550,Phường Quang Trung,268
+9551,Phường La Khê,268
+9552,Phường Phú La,268
+9553,Phường Phúc La,268
+9556,Phường Hà Cầu,268
+9562,Phường Yên Nghĩa,268
+9565,Phường Kiến Hưng,268
+9568,Phường Phú Lãm,268
+9571,Phường Phú Lương,268
+9886,Phường Dương Nội,268
+10117,Phường Đồng Mai,268
+10123,Phường Biên Giang,268
+9574,Phường Lê Lợi,269
+9577,Phường Phú Thịnh,269
+9580,Phường Ngô Quyền,269
+9583,Phường Quang Trung,269
+9586,Phường Sơn Lộc,269
+9589,Phường Xuân Khanh,269
+9592,Xã Đường Lâm,269
+9595,Phường Viên Sơn,269
+9598,Xã Xuân Sơn,269
+9601,Phường Trung Hưng,269
+9604,Xã Thanh Mỹ,269
+9607,Phường Trung Sơn Trầm,269
+9610,Xã Kim Sơn,269
+9613,Xã Sơn Đông,269
+9616,Xã Cổ Đông,269
+9619,Thị trấn Tây Đằng,271
+9625,Xã Phú Cường,271
+9628,Xã Cổ Đô,271
+9631,Xã Tản Hồng,271
+9634,Xã Vạn Thắng,271
+9637,Xã Châu Sơn,271
+9640,Xã Phong Vân,271
+9643,Xã Phú Đông,271
+9646,Xã Phú Phương,271
+9649,Xã Phú Châu,271
+9652,Xã Thái Hòa,271
+9655,Xã Đồng Thái,271
+9658,Xã Phú Sơn,271
+9661,Xã Minh Châu,271
+9664,Xã Vật Lại,271
+9667,Xã Chu Minh,271
+9670,Xã Tòng Bạt,271
+9673,Xã Cẩm Lĩnh,271
+9676,Xã Sơn Đà,271
+9679,Xã Đông Quang,271
+9682,Xã Tiên Phong,271
+9685,Xã Thụy An,271
+9688,Xã Cam Thượng,271
+9691,Xã Thuần Mỹ,271
+9694,Xã Tản Lĩnh,271
+9697,Xã Ba Trại,271
+9700,Xã Minh Quang,271
+9703,Xã Ba Vì,271
+9706,Xã Vân Hòa,271
+9709,Xã Yên Bài,271
+9712,Xã Khánh Thượng,271
+9715,Thị trấn Phúc Thọ,272
+9718,Xã Vân Hà,272
+9721,Xã Vân Phúc,272
+9724,Xã Vân Nam,272
+9727,Xã Xuân Đình,272
+9733,Xã Sen Phương,272
+9739,Xã Võng Xuyên,272
+9742,Xã Thọ Lộc,272
+9745,Xã Long Xuyên,272
+9748,Xã Thượng Cốc,272
+9751,Xã Hát Môn,272
+9754,Xã Tích Giang,272
+9757,Xã Thanh Đa,272
+9760,Xã Trạch Mỹ Lộc,272
+9763,Xã Phúc Hòa,272
+9766,Xã Ngọc Tảo,272
+9769,Xã Phụng Thượng,272
+9772,Xã Tam Thuấn,272
+9775,Xã Tam Hiệp,272
+9778,Xã Hiệp Thuận,272
+9781,Xã Liên Hiệp,272
+9784,Thị trấn Phùng,273
+9787,Xã Trung Châu,273
+9790,Xã Thọ An,273
+9793,Xã Thọ Xuân,273
+9796,Xã Hồng Hà,273
+9799,Xã Liên Hồng,273
+9802,Xã Liên Hà,273
+9805,Xã Hạ Mỗ,273
+9808,Xã Liên Trung,273
+9811,Xã Phương Đình,273
+9814,Xã Thượng Mỗ,273
+9817,Xã Tân Hội,273
+9820,Xã Tân Lập,273
+9823,Xã Đan Phượng,273
+9826,Xã Đồng Tháp,273
+9829,Xã Song Phượng,273
+9832,Thị trấn Trạm Trôi,274
+9835,Xã Đức Thượng,274
+9838,Xã Minh Khai,274
+9841,Xã Dương Liễu,274
+9844,Xã Di Trạch,274
+9847,Xã Đức Giang,274
+9850,Xã Cát Quế,274
+9853,Xã Kim Chung,274
+9856,Xã Yên Sở,274
+9859,Xã Sơn Đồng,274
+9862,Xã Vân Canh,274
+9865,Xã Đắc Sở,274
+9868,Xã Lại Yên,274
+9871,Xã Tiền Yên,274
+9874,Xã Song Phương,274
+9877,Xã An Khánh,274
+9880,Xã An Thượng,274
+9883,Xã Vân Côn,274
+9889,Xã La Phù,274
+9892,Xã Đông La,274
+4939,Xã Đông Xuân,275
+9895,Thị trấn Quốc Oai,275
+9898,Xã Sài Sơn,275
+9901,Xã Phượng Cách,275
+9904,Xã Yên Sơn,275
+9907,Xã Ngọc Liệp,275
+9910,Xã Ngọc Mỹ,275
+9913,Xã Liệp Tuyết,275
+9916,Xã Thạch Thán,275
+9919,Xã Đồng Quang,275
+9922,Xã Phú Cát,275
+9925,Xã Tuyết Nghĩa,275
+9928,Xã Nghĩa Hương,275
+9931,Xã Cộng Hòa,275
+9934,Xã Tân Phú,275
+9937,Xã Đại Thành,275
+9940,Xã Phú Mãn,275
+9943,Xã Cấn Hữu,275
+9946,Xã Tân Hòa,275
+9949,Xã Hòa Thạch,275
+9952,Xã Đông Yên,275
+4927,Xã Yên Trung,276
+4930,Xã Yên Bình,276
+4936,Xã Tiến Xuân,276
+9955,Thị trấn Liên Quan,276
+9958,Xã Đại Đồng,276
+9961,Xã Cẩm Yên,276
+9964,Xã Lại Thượng,276
+9967,Xã Phú Kim,276
+9970,Xã Hương Ngải,276
+9973,Xã Canh Nậu,276
+9976,Xã Kim Quan,276
+9979,Xã Dị Nậu,276
+9982,Xã Bình Yên,276
+9985,Xã Chàng Sơn,276
+9988,Xã Thạch Hoà,276
+9991,Xã Cần Kiệm,276
+9994,Xã Hữu Bằng,276
+9997,Xã Phùng Xá,276
+10000,Xã Tân Xã,276
+10003,Xã Thạch Xá,276
+10006,Xã Bình Phú,276
+10009,Xã Hạ Bằng,276
+10012,Xã Đồng Trúc,276
+10015,Thị trấn Chúc Sơn,277
+10018,Thị trấn Xuân Mai,277
+10021,Xã Phụng Châu,277
+10024,Xã Tiên Phương,277
+10027,Xã Đông Sơn,277
+10030,Xã Đông Phương Yên,277
+10033,Xã Phú Nghĩa,277
+10039,Xã Trường Yên,277
+10042,Xã Ngọc Hòa,277
+10045,Xã Thủy Xuân Tiên,277
+10048,Xã Thanh Bình,277
+10051,Xã Trung Hòa,277
+10054,Xã Đại Yên,277
+10057,Xã Thụy Hương,277
+10060,Xã Tốt Động,277
+10063,Xã Lam Điền,277
+10066,Xã Tân Tiến,277
+10069,Xã Nam Phương Tiến,277
+10072,Xã Hợp Đồng,277
+10075,Xã Hoàng Văn Thụ,277
+10078,Xã Hoàng Diệu,277
+10081,Xã Hữu Văn,277
+10084,Xã Quảng Bị,277
+10087,Xã Mỹ Lương,277
+10090,Xã Thượng Vực,277
+10093,Xã Hồng Phong,277
+10096,Xã Đồng Phú,277
+10099,Xã Trần Phú,277
+10102,Xã Văn Võ,277
+10105,Xã Đồng Lạc,277
+10108,Xã Hòa Chính,277
+10111,Xã Phú Nam An,277
+10114,Thị trấn Kim Bài,278
+10120,Xã Cự Khê,278
+10126,Xã Bích Hòa,278
+10129,Xã Mỹ Hưng,278
+10132,Xã Cao Viên,278
+10135,Xã Bình Minh,278
+10138,Xã Tam Hưng,278
+10141,Xã Thanh Cao,278
+10144,Xã Thanh Thùy,278
+10147,Xã Thanh Mai,278
+10150,Xã Thanh Văn,278
+10153,Xã Đỗ Động,278
+10156,Xã Kim An,278
+10159,Xã Kim Thư,278
+10162,Xã Phương Trung,278
+10165,Xã Tân Ước,278
+10168,Xã Dân Hòa,278
+10171,Xã Liên Châu,278
+10174,Xã Cao Dương,278
+10177,Xã Xuân Dương,278
+10180,Xã Hồng Dương,278
+10183,Thị trấn Thường Tín,279
+10186,Xã Ninh Sở,279
+10189,Xã Nhị Khê,279
+10192,Xã Duyên Thái,279
+10195,Xã Khánh Hà,279
+10198,Xã Hòa Bình,279
+10201,Xã Văn Bình,279
+10204,Xã Hiền Giang,279
+10207,Xã Hồng Vân,279
+10210,Xã Vân Tảo,279
+10213,Xã Liên Phương,279
+10216,Xã Văn Phú,279
+10219,Xã Tự Nhiên,279
+10222,Xã Tiền Phong,279
+10225,Xã Hà Hồi,279
+10228,Xã Thư Phú,279
+10231,Xã Nguyễn Trãi,279
+10234,Xã Quất Động,279
+10237,Xã Chương Dương,279
+10240,Xã Tân Minh,279
+10243,Xã Lê Lợi,279
+10246,Xã Thắng Lợi,279
+10249,Xã Dũng Tiến,279
+10252,Xã Thống Nhất,279
+10255,Xã Nghiêm Xuyên,279
+10258,Xã Tô Hiệu,279
+10261,Xã Văn Tự,279
+10264,Xã Vạn Điểm,279
+10267,Xã Minh Cường,279
+10270,Thị trấn Phú Minh,280
+10273,Thị trấn Phú Xuyên,280
+10276,Xã Hồng Minh,280
+10279,Xã Phượng Dực,280
+10282,Xã Nam Tiến,280
+10288,Xã Tri Trung,280
+10291,Xã Đại Thắng,280
+10294,Xã Phú Túc,280
+10297,Xã Văn Hoàng,280
+10300,Xã Hồng Thái,280
+10303,Xã Hoàng Long,280
+10306,Xã Quang Trung,280
+10309,Xã Nam Phong,280
+10312,Xã Nam Triều,280
+10315,Xã Tân Dân,280
+10318,Xã Sơn Hà,280
+10321,Xã Chuyên Mỹ,280
+10324,Xã Khai Thái,280
+10327,Xã Phúc Tiến,280
+10330,Xã Vân Từ,280
+10333,Xã Tri Thủy,280
+10336,Xã Đại Xuyên,280
+10339,Xã Phú Yên,280
+10342,Xã Bạch Hạ,280
+10345,Xã Quang Lãng,280
+10348,Xã Châu Can,280
+10351,Xã Minh Tân,280
+10354,Thị trấn Vân Đình,281
+10357,Xã Viên An,281
+10360,Xã Viên Nội,281
+10363,Xã Hoa Sơn,281
+10366,Xã Quảng Phú Cầu,281
+10369,Xã Trường Thịnh,281
+10372,Xã Cao Thành,281
+10375,Xã Liên Bạt,281
+10378,Xã Sơn Công,281
+10381,Xã Đồng Tiến,281
+10384,Xã Phương Tú,281
+10387,Xã Trung Tú,281
+10390,Xã Đồng Tân,281
+10393,Xã Tảo Dương Văn,281
+10396,Xã Vạn Thái,281
+10399,Xã Minh Đức,281
+10402,Xã Hòa Lâm,281
+10405,Xã Hòa Xá,281
+10408,Xã Trầm Lộng,281
+10411,Xã Kim Đường,281
+10414,Xã Hòa Nam,281
+10417,Xã Hòa Phú,281
+10420,Xã Đội Bình,281
+10423,Xã Đại Hùng,281
+10426,Xã Đông Lỗ,281
+10429,Xã Phù Lưu,281
+10432,Xã Đại Cường,281
+10435,Xã Lưu Hoàng,281
+10438,Xã Hồng Quang,281
+10441,Thị trấn Đại Nghĩa,282
+10444,Xã Đồng Tâm,282
+10447,Xã Thượng Lâm,282
+10450,Xã Tuy Lai,282
+10453,Xã Phúc Lâm,282
+10456,Xã Mỹ Thành,282
+10459,Xã Bột Xuyên,282
+10462,Xã An Mỹ,282
+10465,Xã Hồng Sơn,282
+10468,Xã Lê Thanh,282
+10471,Xã Xuy Xá,282
+10474,Xã Phùng Xá,282
+10477,Xã Phù Lưu Tế,282
+10480,Xã Đại Hưng,282
+10483,Xã Vạn Kim,282
+10486,Xã Đốc Tín,282
+10489,Xã Hương Sơn,282
+10492,Xã Hùng Tiến,282
+10495,Xã An Tiến,282
+10498,Xã Hợp Tiến,282
+10501,Xã Hợp Thanh,282
+10504,Xã An Phú,282
+688,Phường Quang Trung,24
+691,Phường Trần Phú,24
+692,Phường Ngọc Hà,24
+694,Phường Nguyễn Trãi,24
+697,Phường Minh Khai,24
+700,Xã Ngọc Đường,24
+946,Xã Phương Độ,24
+949,Xã Phương Thiện,24
+712,Thị trấn Phó Bảng,26
+715,Xã Lũng Cú,26
+718,Xã Má Lé,26
+721,Thị trấn Đồng Văn,26
+724,Xã Lũng Táo,26
+727,Xã Phố Là,26
+730,Xã Thài Phìn Tủng,26
+733,Xã Sủng Là,26
+736,Xã Xà Phìn,26
+739,Xã Tả Phìn,26
+742,Xã Tả Lủng,26
+745,Xã Phố Cáo,26
+748,Xã Sính Lủng,26
+751,Xã Sảng Tủng,26
+754,Xã Lũng Thầu,26
+757,Xã Hố Quáng Phìn,26
+760,Xã Vần Chải,26
+763,Xã Lũng Phìn,26
+766,Xã Sủng Trái,26
+769,Thị trấn Mèo Vạc,27
+772,Xã Thượng Phùng,27
+775,Xã Pải Lủng,27
+778,Xã Xín Cái,27
+781,Xã Pả Vi,27
+784,Xã Giàng Chu Phìn,27
+787,Xã Sủng Trà,27
+790,Xã Sủng Máng,27
+793,Xã Sơn Vĩ,27
+796,Xã Tả Lủng,27
+799,Xã Cán Chu Phìn,27
+802,Xã Lũng Pù,27
+805,Xã Lũng Chinh,27
+808,Xã Tát Ngà,27
+811,Xã Nậm Ban,27
+814,Xã Khâu Vai,27
+815,Xã Niêm Tòng,27
+817,Xã Niêm Sơn,27
+820,Thị trấn Yên Minh,28
+823,Xã Thắng Mố,28
+826,Xã Phú Lũng,28
+829,Xã Sủng Tráng,28
+832,Xã Bạch Đích,28
+835,Xã Na Khê,28
+838,Xã Sủng Thài,28
+841,Xã Hữu Vinh,28
+844,Xã Lao Và Chải,28
+847,Xã Mậu Duệ,28
+850,Xã Đông Minh,28
+853,Xã Mậu Long,28
+856,Xã Ngam La,28
+859,Xã Ngọc Long,28
+862,Xã Đường Thượng,28
+865,Xã Lũng Hồ,28
+868,Xã Du Tiến,28
+871,Xã Du Già,28
+874,Thị trấn Tam Sơn,29
+877,Xã Bát Đại Sơn,29
+880,Xã Nghĩa Thuận,29
+883,Xã Cán Tỷ,29
+886,Xã Cao Mã Pờ,29
+889,Xã Thanh Vân,29
+892,Xã Tùng Vài,29
+895,Xã Đông Hà,29
+898,Xã Quản Bạ,29
+901,Xã Lùng Tám,29
+904,Xã Quyết Tiến,29
+907,Xã Tả Ván,29
+910,Xã Thái An,29
+703,Xã Kim Thạch,30
+706,Xã Phú Linh,30
+709,Xã Kim Linh,30
+913,Thị trấn Vị Xuyên,30
+916,Thị trấn Nông Trường Việt Lâm,30
+919,Xã Minh Tân,30
+922,Xã Thuận Hoà,30
+925,Xã Tùng Bá,30
+928,Xã Thanh Thủy,30
+931,Xã Thanh Đức,30
+934,Xã Phong Quang,30
+937,Xã Xín Chải,30
+940,Xã Phương Tiến,30
+943,Xã Lao Chải,30
+952,Xã Cao Bồ,30
+955,Xã Đạo Đức,30
+958,Xã Thượng Sơn,30
+961,Xã Linh Hồ,30
+964,Xã Quảng Ngần,30
+967,Xã Việt Lâm,30
+970,Xã Ngọc Linh,30
+973,Xã Ngọc Minh,30
+976,Xã Bạch Ngọc,30
+979,Xã Trung Thành,30
+982,Xã Minh Sơn,31
+985,Xã Giáp Trung,31
+988,Xã Yên Định,31
+991,Thị trấn Yên Phú,31
+994,Xã Minh Ngọc,31
+997,Xã Yên Phong,31
+1000,Xã Lạc Nông,31
+1003,Xã Phú Nam,31
+1006,Xã Yên Cường,31
+1009,Xã Thượng Tân,31
+1012,Xã Đường Âm,31
+1015,Xã Đường Hồng,31
+1018,Xã Phiêng Luông,31
+1021,Thị trấn Vinh Quang,32
+1024,Xã Bản Máy,32
+1027,Xã Thàng Tín,32
+1030,Xã Thèn Chu Phìn,32
+1033,Xã Pố Lồ,32
+1036,Xã Bản Phùng,32
+1039,Xã Túng Sán,32
+1042,Xã Chiến Phố,32
+1045,Xã Đản Ván,32
+1048,Xã Tụ Nhân,32
+1051,Xã Tân Tiến,32
+1054,Xã Nàng Đôn,32
+1057,Xã Pờ Ly Ngài,32
+1060,Xã Sán Xả Hồ,32
+1063,Xã Bản Luốc,32
+1066,Xã Ngàm Đăng Vài,32
+1069,Xã Bản Nhùng,32
+1072,Xã Tả Sử Choóng,32
+1075,Xã Nậm Dịch,32
+1081,Xã Hồ Thầu,32
+1084,Xã Nam Sơn,32
+1087,Xã Nậm Tỵ,32
+1090,Xã Thông Nguyên,32
+1093,Xã Nậm Khòa,32
+1096,Thị trấn Cốc Pài,33
+1099,Xã Nàn Xỉn,33
+1102,Xã Bản Díu,33
+1105,Xã Chí Cà,33
+1108,Xã Xín Mần,33
+1114,Xã Thèn Phàng,33
+1117,Xã Trung Thịnh,33
+1120,Xã Pà Vầy Sủ,33
+1123,Xã Cốc Rế,33
+1126,Xã Thu Tà,33
+1129,Xã Nàn Ma,33
+1132,Xã Tả Nhìu,33
+1135,Xã Bản Ngò,33
+1138,Xã Chế Là,33
+1141,Xã Nấm Dẩn,33
+1144,Xã Quảng Nguyên,33
+1147,Xã Nà Chì,33
+1150,Xã Khuôn Lùng,33
+1153,Thị trấn Việt Quang,34
+1156,Thị trấn Vĩnh Tuy,34
+1159,Xã Tân Lập,34
+1162,Xã Tân Thành,34
+1165,Xã Đồng Tiến,34
+1168,Xã Đồng Tâm,34
+1171,Xã Tân Quang,34
+1174,Xã Thượng Bình,34
+1177,Xã Hữu Sản,34
+1180,Xã Kim Ngọc,34
+1183,Xã Việt Vinh,34
+1186,Xã Bằng Hành,34
+1189,Xã Quang Minh,34
+1192,Xã Liên Hiệp,34
+1195,Xã Vô Điếm,34
+1198,Xã Việt Hồng,34
+1201,Xã Hùng An,34
+1204,Xã Đức Xuân,34
+1207,Xã Tiên Kiều,34
+1210,Xã Vĩnh Hảo,34
+1213,Xã Vĩnh Phúc,34
+1216,Xã Đồng Yên,34
+1219,Xã Đông Thành,34
+1222,Xã Xuân Minh,35
+1225,Xã Tiên Nguyên,35
+1228,Xã Tân Nam,35
+1231,Xã Bản Rịa,35
+1234,Xã Yên Thành,35
+1237,Thị trấn Yên Bình,35
+1240,Xã Tân Trịnh,35
+1243,Xã Tân Bắc,35
+1246,Xã Bằng Lang,35
+1249,Xã Yên Hà,35
+1252,Xã Hương Sơn,35
+1255,Xã Xuân Giang,35
+1258,Xã Nà Khương,35
+1261,Xã Tiên Yên,35
+1264,Xã Vĩ Thượng,35
+1267,Phường Sông Hiến,40
+1270,Phường Sông Bằng,40
+1273,Phường Hợp Giang,40
+1276,Phường Tân Giang,40
+1279,Phường Ngọc Xuân,40
+1282,Phường Đề Thám,40
+1285,Phường Hoà Chung,40
+1288,Phường Duyệt Trung,40
+1693,Xã Vĩnh Quang,40
+1705,Xã Hưng Đạo,40
+1720,Xã Chu Trinh,40
+1290,Thị trấn Pác Miầu,42
+1291,Xã Đức Hạnh,42
+1294,Xã Lý Bôn,42
+1296,Xã Nam Cao,42
+1297,Xã Nam Quang,42
+1300,Xã Vĩnh Quang,42
+1303,Xã Quảng Lâm,42
+1304,Xã Thạch Lâm,42
+1309,Xã Vĩnh Phong,42
+1312,Xã Mông Ân,42
+1315,Xã Thái Học,42
+1316,Xã Thái Sơn,42
+1318,Xã Yên Thổ,42
+1321,Thị trấn Bảo Lạc,43
+1324,Xã Cốc Pàng,43
+1327,Xã Thượng Hà,43
+1330,Xã Cô Ba,43
+1333,Xã Bảo Toàn,43
+1336,Xã Khánh Xuân,43
+1339,Xã Xuân Trường,43
+1342,Xã Hồng Trị,43
+1343,Xã Kim Cúc,43
+1345,Xã Phan Thanh,43
+1348,Xã Hồng An,43
+1351,Xã Hưng Đạo,43
+1352,Xã Hưng Thịnh,43
+1354,Xã Huy Giáp,43
+1357,Xã Đình Phùng,43
+1359,Xã Sơn Lập,43
+1360,Xã Sơn Lộ,43
+1363,Thị trấn Thông Nông,45
+1366,Xã Cần Yên,45
+1367,Xã Cần Nông,45
+1372,Xã Lương Thông,45
+1375,Xã Đa Thông,45
+1378,Xã Ngọc Động,45
+1381,Xã Yên Sơn,45
+1384,Xã Lương Can,45
+1387,Xã Thanh Long,45
+1392,Thị trấn Xuân Hòa,45
+1393,Xã Lũng Nặm,45
+1399,Xã Trường Hà,45
+1402,Xã Cải Viên,45
+1411,Xã Nội Thôn,45
+1414,Xã Tổng Cọt,45
+1417,Xã Sóc Hà,45
+1420,Xã Thượng Thôn,45
+1429,Xã Hồng Sỹ,45
+1432,Xã Quý Quân,45
+1435,Xã Mã Ba,45
+1438,Xã Ngọc Đào,45
+1447,Thị trấn Trà Lĩnh,47
+1453,Xã Tri Phương,47
+1456,Xã Quang Hán,47
+1462,Xã Xuân Nội,47
+1465,Xã Quang Trung,47
+1468,Xã Quang Vinh,47
+1471,Xã Cao Chương,47
+1477,Thị trấn Trùng Khánh,47
+1480,Xã Ngọc Khê,47
+1481,Xã Ngọc Côn,47
+1483,Xã Phong Nậm,47
+1489,Xã Đình Phong,47
+1495,Xã Đàm Thuỷ,47
+1498,Xã Khâm Thành,47
+1501,Xã Chí Viễn,47
+1504,Xã Lăng Hiếu,47
+1507,Xã Phong Châu,47
+1516,Xã Trung Phúc,47
+1519,Xã Cao Thăng,47
+1522,Xã Đức Hồng,47
+1525,Xã Đoài Dương,47
+1534,Xã Minh Long,48
+1537,Xã Lý Quốc,48
+1540,Xã Thắng Lợi,48
+1543,Xã Đồng Loan,48
+1546,Xã Đức Quang,48
+1549,Xã Kim Loan,48
+1552,Xã Quang Long,48
+1555,Xã An Lạc,48
+1558,Thị trấn Thanh Nhật,48
+1561,Xã Vinh Quý,48
+1564,Xã Thống Nhất,48
+1567,Xã Cô Ngân,48
+1573,Xã Thị Hoa,48
+1474,Xã Quốc Toản,49
+1576,Thị trấn Quảng Uyên,49
+1579,Xã Phi Hải,49
+1582,Xã Quảng Hưng,49
+1594,Xã Độc Lập,49
+1597,Xã Cai Bộ,49
+1603,Xã Phúc Sen,49
+1606,Xã Chí Thảo,49
+1609,Xã Tự Do,49
+1615,Xã Hồng Quang,49
+1618,Xã Ngọc Động,49
+1624,Xã Hạnh Phúc,49
+1627,Thị trấn Tà Lùng,49
+1630,Xã Bế Văn Đàn,49
+1636,Xã Cách Linh,49
+1639,Xã Đại Sơn,49
+1645,Xã Tiên Thành,49
+1648,Thị trấn Hoà Thuận,49
+1651,Xã Mỹ Hưng,49
+1654,Thị trấn Nước Hai,51
+1657,Xã Dân Chủ,51
+1660,Xã Nam Tuấn,51
+1666,Xã Đại Tiến,51
+1669,Xã Đức Long,51
+1672,Xã Ngũ Lão,51
+1675,Xã Trương Lương,51
+1687,Xã Hồng Việt,51
+1696,Xã Hoàng Tung,51
+1699,Xã Nguyễn Huệ,51
+1702,Xã Quang Trung,51
+1708,Xã Bạch Đằng,51
+1711,Xã Bình Dương,51
+1714,Xã Lê Chung,51
+1723,Xã Hồng Nam,51
+1726,Thị trấn Nguyên Bình,52
+1729,Thị trấn Tĩnh Túc,52
+1732,Xã Yên Lạc,52
+1735,Xã Triệu Nguyên,52
+1738,Xã Ca Thành,52
+1744,Xã Vũ Nông,52
+1747,Xã Minh Tâm,52
+1750,Xã Thể Dục,52
+1756,Xã Mai Long,52
+1762,Xã Vũ Minh,52
+1765,Xã Hoa Thám,52
+1768,Xã Phan Thanh,52
+1771,Xã Quang Thành,52
+1774,Xã Tam Kim,52
+1777,Xã Thành Công,52
+1780,Xã Thịnh Vượng,52
+1783,Xã Hưng Đạo,52
+1786,Thị trấn Đông Khê,53
+1789,Xã Canh Tân,53
+1792,Xã Kim Đồng,53
+1795,Xã Minh Khai,53
+1801,Xã Đức Thông,53
+1804,Xã Thái Cường,53
+1807,Xã Vân Trình,53
+1810,Xã Thụy Hùng,53
+1813,Xã Quang Trọng,53
+1816,Xã Trọng Con,53
+1819,Xã Lê Lai,53
+1822,Xã Đức Long,53
+1828,Xã Lê Lợi,53
+1831,Xã Đức Xuân,53
+1834,Phường Nguyễn Thị Minh Khai,58
+1837,Phường Sông Cầu,58
+1840,Phường Đức Xuân,58
+1843,Phường Phùng Chí Kiên,58
+1846,Phường Huyền Tụng,58
+1849,Xã Dương Quang,58
+1852,Xã Nông Thượng,58
+1855,Phường Xuất Hóa,58
+1858,Xã Bằng Thành,60
+1861,Xã Nhạn Môn,60
+1864,Xã Bộc Bố,60
+1867,Xã Công Bằng,60
+1870,Xã Giáo Hiệu,60
+1873,Xã Xuân La,60
+1876,Xã An Thắng,60
+1879,Xã Cổ Linh,60
+1882,Xã Nghiên Loan,60
+1885,Xã Cao Tân,60
+1888,Thị trấn Chợ Rã,61
+1891,Xã Bành Trạch,61
+1894,Xã Phúc Lộc,61
+1897,Xã Hà Hiệu,61
+1900,Xã Cao Thượng,61
+1906,Xã Khang Ninh,61
+1909,Xã Nam Mẫu,61
+1912,Xã Thượng Giáo,61
+1915,Xã Địa Linh,61
+1918,Xã Yến Dương,61
+1921,Xã Chu Hương,61
+1924,Xã Quảng Khê,61
+1927,Xã Mỹ Phương,61
+1930,Xã Hoàng Trĩ,61
+1933,Xã Đồng Phúc,61
+1936,Thị trấn Nà Phặc,62
+1939,Xã Thượng Ân,62
+1942,Xã Bằng Vân,62
+1945,Xã Cốc Đán,62
+1948,Xã Trung Hoà,62
+1951,Xã Đức Vân,62
+1954,Xã Vân Tùng,62
+1957,Xã Thượng Quan,62
+1960,Xã Hiệp Lực,62
+1963,Xã Thuần Mang,62
+1969,Thị trấn Phủ Thông,63
+1975,Xã Vi Hương,63
+1978,Xã Sĩ Bình,63
+1981,Xã Vũ Muộn,63
+1984,Xã Đôn Phong,63
+1990,Xã Lục Bình,63
+1993,Xã Tân Tú,63
+1999,Xã Nguyên Phúc,63
+2002,Xã Cao Sơn,63
+2005,Xã Quân Hà,63
+2008,Xã Cẩm Giàng,63
+2011,Xã Mỹ Thanh,63
+2014,Xã Dương Phong,63
+2017,Xã Quang Thuận,63
+2020,Thị trấn Bằng Lũng,64
+2023,Xã Xuân Lạc,64
+2026,Xã Nam Cường,64
+2029,Xã Đồng Lạc,64
+2032,Xã Tân Lập,64
+2035,Xã Bản Thi,64
+2038,Xã Quảng Bạch,64
+2041,Xã Bằng Phúc,64
+2044,Xã Yên Thịnh,64
+2047,Xã Yên Thượng,64
+2050,Xã Phương Viên,64
+2053,Xã Ngọc Phái,64
+2059,Xã Đồng Thắng,64
+2062,Xã Lương Bằng,64
+2065,Xã Bằng Lãng,64
+2068,Xã Đại Sảo,64
+2071,Xã Nghĩa Tá,64
+2077,Xã Yên Mỹ,64
+2080,Xã Bình Trung,64
+2083,Xã Yên Phong,64
+2086,Thị trấn Đồng Tâm,65
+2089,Xã Tân Sơn,65
+2092,Xã Thanh Vận,65
+2095,Xã Mai Lạp,65
+2098,Xã Hoà Mục,65
+2101,Xã Thanh Mai,65
+2104,Xã Cao Kỳ,65
+2107,Xã Nông Hạ,65
+2110,Xã Yên Cư,65
+2113,Xã Thanh Thịnh,65
+2116,Xã Yên Hân,65
+2122,Xã Như Cố,65
+2125,Xã Bình Văn,65
+2131,Xã Quảng Chu,65
+2137,Xã Văn Vũ,66
+2140,Xã Văn Lang,66
+2143,Xã Lương Thượng,66
+2146,Xã Kim Hỷ,66
+2152,Xã Cường Lợi,66
+2155,Thị trấn Yến Lạc,66
+2158,Xã Kim Lư,66
+2161,Xã Sơn Thành,66
+2170,Xã Văn Minh,66
+2173,Xã Côn Minh,66
+2176,Xã Cư Lễ,66
+2179,Xã Trần Phú,66
+2185,Xã Quang Phong,66
+2188,Xã Dương Sơn,66
+2191,Xã Xuân Dương,66
+2194,Xã Đổng Xá,66
+2197,Xã Liêm Thuỷ,66
+2200,Phường Phan Thiết,70
+2203,Phường Minh Xuân,70
+2206,Phường Tân Quang,70
+2209,Xã Tràng Đà,70
+2212,Phường Nông Tiến,70
+2215,Phường Ỷ La,70
+2216,Phường Tân Hà,70
+2218,Phường Hưng Thành,70
+2497,Xã Kim Phú,70
+2503,Xã An Khang,70
+2509,Phường Mỹ Lâm,70
+2512,Phường An Tường,70
+2515,Xã Lưỡng Vượng,70
+2521,Xã Thái Long,70
+2524,Phường Đội Cấn,70
+2233,Xã Phúc Yên,71
+2242,Xã Xuân Lập,71
+2251,Xã Khuôn Hà,71
+2266,Thị trấn Lăng Can,71
+2269,Xã Thượng Lâm,71
+2290,Xã Bình An,71
+2293,Xã Hồng Quang,71
+2296,Xã Thổ Bình,71
+2299,Xã Phúc Sơn,71
+2302,Xã Minh Quang,71
+2221,Thị trấn Na Hang,72
+2227,Xã Sinh Long,72
+2230,Xã Thượng Giáp,72
+2239,Xã Thượng Nông,72
+2245,Xã Côn Lôn,72
+2248,Xã Yên Hoa,72
+2254,Xã Hồng Thái,72
+2260,Xã Đà Vị,72
+2263,Xã Khau Tinh,72
+2275,Xã Sơn Phú,72
+2281,Xã Năng Khả,72
+2284,Xã Thanh Tương,72
+2287,Thị trấn Vĩnh Lộc,73
+2305,Xã Trung Hà,73
+2308,Xã Tân Mỹ,73
+2311,Xã Hà Lang,73
+2314,Xã Hùng Mỹ,73
+2317,Xã Yên Lập,73
+2320,Xã Tân An,73
+2323,Xã Bình Phú,73
+2326,Xã Xuân Quang,73
+2329,Xã Ngọc Hội,73
+2332,Xã Phú Bình,73
+2335,Xã Hòa Phú,73
+2338,Xã Phúc Thịnh,73
+2341,Xã Kiên Đài,73
+2344,Xã Tân Thịnh,73
+2347,Xã Trung Hòa,73
+2350,Xã Kim Bình,73
+2353,Xã Hòa An,73
+2356,Xã Vinh Quang,73
+2359,Xã Tri Phú,73
+2362,Xã Nhân Lý,73
+2365,Xã Yên Nguyên,73
+2368,Xã Linh Phú,73
+2371,Xã Bình Nhân,73
+2374,Thị trấn Tân Yên,74
+2377,Xã Yên Thuận,74
+2380,Xã Bạch Xa,74
+2383,Xã Minh Khương,74
+2386,Xã Yên Lâm,74
+2389,Xã Minh Dân,74
+2392,Xã Phù Lưu,74
+2395,Xã Minh Hương,74
+2398,Xã Yên Phú,74
+2401,Xã Tân Thành,74
+2404,Xã Bình Xa,74
+2407,Xã Thái Sơn,74
+2410,Xã Nhân Mục,74
+2413,Xã Thành Long,74
+2416,Xã Bằng Cốc,74
+2419,Xã Thái Hòa,74
+2422,Xã Đức Ninh,74
+2425,Xã Hùng Đức,74
+2431,Xã Quí Quân,75
+2434,Xã Lực Hành,75
+2437,Xã Kiến Thiết,75
+2440,Xã Trung Minh,75
+2443,Xã Chiêu Yên,75
+2446,Xã Trung Trực,75
+2449,Xã Xuân Vân,75
+2452,Xã Phúc Ninh,75
+2455,Xã Hùng Lợi,75
+2458,Xã Trung Sơn,75
+2461,Xã Tân Tiến,75
+2464,Xã Tứ Quận,75
+2467,Xã Đạo Viện,75
+2470,Xã Tân Long,75
+2473,Thị trấn Yên Sơn,75
+2476,Xã Kim Quan,75
+2479,Xã Lang Quán,75
+2482,Xã Phú Thịnh,75
+2485,Xã Công Đa,75
+2488,Xã Trung Môn,75
+2491,Xã Chân Sơn,75
+2494,Xã Thái Bình,75
+2500,Xã Tiến Bộ,75
+2506,Xã Mỹ Bằng,75
+2518,Xã Hoàng Khai,75
+2527,Xã Nhữ Hán,75
+2530,Xã Nhữ Khê,75
+2533,Xã Đội Bình,75
+2536,Thị trấn Sơn Dương,76
+2539,Xã Trung Yên,76
+2542,Xã Minh Thanh,76
+2545,Xã Tân Trào,76
+2548,Xã Vĩnh Lợi,76
+2551,Xã Thượng Ấm,76
+2554,Xã Bình Yên,76
+2557,Xã Lương Thiện,76
+2560,Xã Tú Thịnh,76
+2563,Xã Cấp Tiến,76
+2566,Xã Hợp Thành,76
+2569,Xã Phúc Ứng,76
+2572,Xã Đông Thọ,76
+2575,Xã Kháng Nhật,76
+2578,Xã Hợp Hòa,76
+2584,Xã Quyết Thắng,76
+2587,Xã Đồng Quý,76
+2590,Xã Tân Thanh,76
+2593,Xã Vân Sơn,76
+2596,Xã Văn Phú,76
+2599,Xã Chi Thiết,76
+2602,Xã Đông Lợi,76
+2605,Xã Thiện Kế,76
+2608,Xã Hồng Lạc,76
+2611,Xã Phú Lương,76
+2614,Xã Ninh Lai,76
+2617,Xã Đại Phú,76
+2620,Xã Sơn Nam,76
+2623,Xã Hào Phú,76
+2626,Xã Tam Đa,76
+2632,Xã Trường Sinh,76
+2635,Phường Duyên Hải,80
+2641,Phường Lào Cai,80
+2644,Phường Cốc Lếu,80
+2647,Phường Kim Tân,80
+2650,Phường Bắc Lệnh,80
+2653,Phường Pom Hán,80
+2656,Phường Xuân Tăng,80
+2658,Phường Bình Minh,80
+2659,Xã Thống Nhất,80
+2662,Xã Đồng Tuyển,80
+2665,Xã Vạn Hoà,80
+2668,Phường Bắc Cường,80
+2671,Phường Nam Cường,80
+2674,Xã Cam Đường,80
+2677,Xã Tả Phời,80
+2680,Xã Hợp Thành,80
+2746,Xã Cốc San,80
+2683,Thị trấn Bát Xát,82
+2686,Xã A Mú Sung,82
+2689,Xã Nậm Chạc,82
+2692,Xã A Lù,82
+2695,Xã Trịnh Tường,82
+2701,Xã Y Tý,82
+2704,Xã Cốc Mỳ,82
+2707,Xã Dền Sáng,82
+2710,Xã Bản Vược,82
+2713,Xã Sàng Ma Sáo,82
+2716,Xã Bản Qua,82
+2719,Xã Mường Vi,82
+2722,Xã Dền Thàng,82
+2725,Xã Bản Xèo,82
+2728,Xã Mường Hum,82
+2731,Xã Trung Lèng Hồ,82
+2734,Xã Quang Kim,82
+2737,Xã Pa Cheo,82
+2740,Xã Nậm Pung,82
+2743,Xã Phìn Ngan,82
+2749,Xã Tòng Sành,82
+2752,Xã Pha Long,83
+2755,Xã Tả Ngải Chồ,83
+2758,Xã Tung Chung Phố,83
+2761,Thị trấn Mường Khương,83
+2764,Xã Dìn Chin,83
+2767,Xã Tả Gia Khâu,83
+2770,Xã Nậm Chảy,83
+2773,Xã Nấm Lư,83
+2776,Xã Lùng Khấu Nhin,83
+2779,Xã Thanh Bình,83
+2782,Xã Cao Sơn,83
+2785,Xã Lùng Vai,83
+2788,Xã Bản Lầu,83
+2791,Xã La Pan Tẩn,83
+2794,Xã Tả Thàng,83
+2797,Xã Bản Sen,83
+2800,Xã Nàn Sán,84
+2803,Xã Thào Chư Phìn,84
+2806,Xã Bản Mế,84
+2809,Thị trấn Si Ma Cai,84
+2812,Xã Sán Chải,84
+2818,Xã Lùng Thẩn,84
+2821,Xã Cán Cấu,84
+2824,Xã Sín Chéng,84
+2827,Xã Quan Hồ Thẩn,84
+2836,Xã Nàn Xín,84
+2839,Thị trấn Bắc Hà,85
+2842,Xã Lùng Cải,85
+2848,Xã Lùng Phình,85
+2851,Xã Tả Van Chư,85
+2854,Xã Tả Củ Tỷ,85
+2857,Xã Thải Giàng Phố,85
+2863,Xã Hoàng Thu Phố,85
+2866,Xã Bản Phố,85
+2869,Xã Bản Liền,85
+2872,Xã Tà Chải,85
+2875,Xã Na Hối,85
+2878,Xã Cốc Ly,85
+2881,Xã Nậm Mòn,85
+2884,Xã Nậm Đét,85
+2887,Xã Nậm Khánh,85
+2890,Xã Bảo Nhai,85
+2893,Xã Nậm Lúc,85
+2896,Xã Cốc Lầu,85
+2899,Xã Bản Cái,85
+2902,Thị trấn N.T Phong Hải,86
+2905,Thị trấn Phố Lu,86
+2908,Thị trấn Tằng Loỏng,86
+2911,Xã Bản Phiệt,86
+2914,Xã Bản Cầm,86
+2917,Xã Thái Niên,86
+2920,Xã Phong Niên,86
+2923,Xã Gia Phú,86
+2926,Xã Xuân Quang,86
+2929,Xã Sơn Hải,86
+2932,Xã Xuân Giao,86
+2935,Xã Trì Quang,86
+2938,Xã Sơn Hà,86
+2944,Xã Phú Nhuận,86
+2947,Thị trấn Phố Ràng,87
+2950,Xã Tân Tiến,87
+2953,Xã Nghĩa Đô,87
+2956,Xã Vĩnh Yên,87
+2959,Xã Điện Quan,87
+2962,Xã Xuân Hoà,87
+2965,Xã Tân Dương,87
+2968,Xã Thượng Hà,87
+2971,Xã Kim Sơn,87
+2974,Xã Cam Cọn,87
+2977,Xã Minh Tân,87
+2980,Xã Xuân Thượng,87
+2983,Xã Việt Tiến,87
+2986,Xã Yên Sơn,87
+2989,Xã Bảo Hà,87
+2992,Xã Lương Sơn,87
+2998,Xã Phúc Khánh,87
+3001,Phường Sa Pa,88
+3002,Phường Sa Pả,88
+3003,Phường Ô Quý Hồ,88
+3004,Xã Ngũ Chỉ Sơn,88
+3006,Phường Phan Si Păng,88
+3010,Xã Trung Chải,88
+3013,Xã Tả Phìn,88
+3016,Phường Hàm Rồng,88
+3019,Xã Hoàng Liên,88
+3022,Xã Thanh Bình,88
+3028,Phường Cầu Mây,88
+3037,Xã Mường Hoa,88
+3040,Xã Tả Van,88
+3043,Xã Mường Bo,88
+3046,Xã Bản Hồ,88
+3052,Xã Liên Minh,88
+3055,Thị trấn Khánh Yên,89
+3061,Xã Võ Lao,89
+3064,Xã Sơn Thuỷ,89
+3067,Xã Nậm Mả,89
+3070,Xã Tân Thượng,89
+3073,Xã Nậm Rạng,89
+3076,Xã Nậm Chầy,89
+3079,Xã Tân An,89
+3082,Xã Khánh Yên Thượng,89
+3085,Xã Nậm Xé,89
+3088,Xã Dần Thàng,89
+3091,Xã Chiềng Ken,89
+3094,Xã Làng Giàng,89
+3097,Xã Hoà Mạc,89
+3100,Xã Khánh Yên Trung,89
+3103,Xã Khánh Yên Hạ,89
+3106,Xã Dương Quỳ,89
+3109,Xã Nậm Tha,89
+3112,Xã Minh Lương,89
+3115,Xã Thẩm Dương,89
+3118,Xã Liêm Phú,89
+3121,Xã Nậm Xây,89
+3124,Phường Noong Bua,94
+3127,Phường Him Lam,94
+3130,Phường Thanh Bình,94
+3133,Phường Tân Thanh,94
+3136,Phường Mường Thanh,94
+3139,Phường Nam Thanh,94
+3142,Phường Thanh Trường,94
+3145,Xã Thanh Minh,94
+3316,Xã Nà Tấu,94
+3317,Xã Nà Nhạn,94
+3325,Xã Mường Phăng,94
+3326,Xã Pá Khoang,94
+3148,Phường Sông Đà,95
+3151,Phường Na Lay,95
+3184,Xã Lay Nưa,95
+3154,Xã Sín Thầu,96
+3155,Xã Sen Thượng,96
+3157,Xã Chung Chải,96
+3158,Xã Leng Su Sìn,96
+3159,Xã Pá Mỳ,96
+3160,Xã Mường Nhé,96
+3161,Xã Nậm Vì,96
+3162,Xã Nậm Kè,96
+3163,Xã Mường Toong,96
+3164,Xã Quảng Lâm,96
+3177,Xã Huổi Lếnh,96
+3172,Thị Trấn Mường Chà,97
+3178,Xã Xá Tổng,97
+3181,Xã Mường Tùng,97
+3190,Xã Hừa Ngài,97
+3191,Xã Huổi Mí,97
+3193,Xã Pa Ham,97
+3194,Xã Nậm Nèn,97
+3196,Xã Huổi Lèng,97
+3197,Xã Sa Lông,97
+3200,Xã Ma Thì Hồ,97
+3201,Xã Na Sang,97
+3202,Xã Mường Mươn,97
+3217,Thị trấn Tủa Chùa,98
+3220,Xã Huổi Só,98
+3223,Xã Xín Chải,98
+3226,Xã Tả Sìn Thàng,98
+3229,Xã Lao Xả Phình,98
+3232,Xã Tả Phìn,98
+3235,Xã Tủa Thàng,98
+3238,Xã Trung Thu,98
+3241,Xã Sính Phình,98
+3244,Xã Sáng Nhè,98
+3247,Xã Mường Đun,98
+3250,Xã Mường Báng,98
+3253,Thị trấn Tuần Giáo,99
+3259,Xã Phình Sáng,99
+3260,Xã Rạng Đông,99
+3262,Xã Mùn Chung,99
+3263,Xã Nà Tòng,99
+3265,Xã Ta Ma,99
+3268,Xã Mường Mùn,99
+3269,Xã Pú Xi,99
+3271,Xã Pú Nhung,99
+3274,Xã Quài Nưa,99
+3277,Xã Mường Thín,99
+3280,Xã Tỏa Tình,99
+3283,Xã Nà Sáy,99
+3284,Xã Mường Khong,99
+3289,Xã Quài Cang,99
+3295,Xã Quài Tở,99
+3298,Xã Chiềng Sinh,99
+3299,Xã Chiềng Đông,99
+3304,Xã Tênh Phông,99
+3319,Xã Mường Pồn,100
+3322,Xã Thanh Nưa,100
+3323,Xã Hua Thanh,100
+3328,Xã Thanh Luông,100
+3331,Xã Thanh Hưng,100
+3334,Xã Thanh Xương,100
+3337,Xã Thanh Chăn,100
+3340,Xã Pa Thơm,100
+3343,Xã Thanh An,100
+3346,Xã Thanh Yên,100
+3349,Xã Noong Luống,100
+3352,Xã Noọng Hẹt,100
+3355,Xã Sam Mứn,100
+3356,Xã Pom Lót,100
+3358,Xã Núa Ngam,100
+3359,Xã Hẹ Muông,100
+3361,Xã Na Ư,100
+3364,Xã Mường Nhà,100
+3365,Xã Na Tông,100
+3367,Xã Mường Lói,100
+3368,Xã Phu Luông,100
+3203,Thị trấn Điện Biên Đông,101
+3205,Xã Na Son,101
+3208,Xã Phì Nhừ,101
+3211,Xã Chiềng Sơ,101
+3214,Xã Mường Luân,101
+3370,Xã Pú Nhi,101
+3371,Xã Nong U,101
+3373,Xã Xa Dung,101
+3376,Xã Keo Lôm,101
+3379,Xã Luân Giới,101
+3382,Xã Phình Giàng,101
+3383,Xã Pú Hồng,101
+3384,Xã Tìa Dình,101
+3385,Xã Háng Lìa,101
+3256,Thị trấn Mường Ảng,102
+3286,Xã Mường Đăng,102
+3287,Xã Ngối Cáy,102
+3292,Xã Ẳng Tở,102
+3301,Xã Búng Lao,102
+3302,Xã Xuân Lao,102
+3307,Xã Ẳng Nưa,102
+3310,Xã Ẳng Cang,102
+3312,Xã Nặm Lịch,102
+3313,Xã Mường Lạn,102
+3156,Xã Nậm Tin,103
+3165,Xã Pa Tần,103
+3166,Xã Chà Cang,103
+3167,Xã Na Cô Sa,103
+3168,Xã Nà Khoa,103
+3169,Xã Nà Hỳ,103
+3170,Xã Nà Bủng,103
+3171,Xã Nậm Nhừ,103
+3173,Xã Nậm Chua,103
+3174,Xã Nậm Khăn,103
+3175,Xã Chà Tở,103
+3176,Xã Vàng Đán,103
+3187,Xã Chà Nưa,103
+3198,Xã Phìn Hồ,103
+3199,Xã Si Pa Phìn,103
+3386,Phường Quyết Thắng,105
+3387,Phường Tân Phong,105
+3388,Phường Quyết Tiến,105
+3389,Phường Đoàn Kết,105
+3403,Xã Sùng Phài,105
+3408,Phường Đông Phong,105
+3409,Xã San Thàng,105
+3390,Thị trấn Tam Đường,106
+3394,Xã Thèn Sin,106
+3400,Xã Tả Lèng,106
+3405,Xã Giang Ma,106
+3406,Xã Hồ Thầu,106
+3412,Xã Bình Lư,106
+3413,Xã Sơn Bình,106
+3415,Xã Nùng Nàng,106
+3418,Xã Bản Giang,106
+3421,Xã Bản Hon,106
+3424,Xã Bản Bo,106
+3427,Xã Nà Tăm,106
+3430,Xã Khun Há,106
+3433,Thị trấn Mường Tè,107
+3436,Xã Thu Lũm,107
+3439,Xã Ka Lăng,107
+3440,Xã Tá Bạ,107
+3442,Xã Pa ủ,107
+3445,Xã Mường Tè,107
+3448,Xã Pa Vệ Sử,107
+3451,Xã Mù Cả,107
+3454,Xã Bum Tở,107
+3457,Xã Nậm Khao,107
+3463,Xã Tà Tổng,107
+3466,Xã Bum Nưa,107
+3467,Xã Vàng San,107
+3469,Xã Kan Hồ,107
+3478,Thị trấn Sìn Hồ,108
+3487,Xã Chăn Nưa,108
+3493,Xã Pa Tần,108
+3496,Xã Phìn Hồ,108
+3499,Xã Hồng Thu,108
+3505,Xã Phăng Sô Lin,108
+3508,Xã Ma Quai,108
+3509,Xã Lùng Thàng,108
+3511,Xã Tả Phìn,108
+3514,Xã Sà Dề Phìn,108
+3517,Xã Nậm Tăm,108
+3520,Xã Tả Ngảo,108
+3523,Xã Pu Sam Cáp,108
+3526,Xã Nậm Cha,108
+3527,Xã Pa Khoá,108
+3529,Xã Làng Mô,108
+3532,Xã Noong Hẻo,108
+3535,Xã Nậm Mạ,108
+3538,Xã Căn Co,108
+3541,Xã Tủa Sín Chải,108
+3544,Xã Nậm Cuổi,108
+3547,Xã Nậm Hăn,108
+3391,Xã Lả Nhì Thàng,109
+3490,Xã Huổi Luông,109
+3549,Thị trấn Phong Thổ,109
+3550,Xã Sì Lở Lầu,109
+3553,Xã Mồ Sì San,109
+3559,Xã Pa Vây Sử,109
+3562,Xã Vàng Ma Chải,109
+3565,Xã Tông Qua Lìn,109
+3568,Xã Mù Sang,109
+3571,Xã Dào San,109
+3574,Xã Ma Ly Pho,109
+3577,Xã Bản Lang,109
+3580,Xã Hoang Thèn,109
+3583,Xã Khổng Lào,109
+3586,Xã Nậm Xe,109
+3589,Xã Mường So,109
+3592,Xã Sin Suối Hồ,109
+3595,Thị trấn Than Uyên,110
+3618,Xã Phúc Than,110
+3619,Xã Mường Than,110
+3625,Xã Mường Mít,110
+3628,Xã Pha Mu,110
+3631,Xã Mường Cang,110
+3632,Xã Hua Nà,110
+3634,Xã Tà Hừa,110
+3637,Xã Mường Kim,110
+3638,Xã Tà Mung,110
+3640,Xã Tà Gia,110
+3643,Xã Khoen On,110
+3598,Thị trấn Tân Uyên,111
+3601,Xã Mường Khoa,111
+3602,Xã Phúc Khoa,111
+3604,Xã Thân Thuộc,111
+3605,Xã Trung Đồng,111
+3607,Xã Hố Mít,111
+3610,Xã Nậm Cần,111
+3613,Xã Nậm Sỏ,111
+3616,Xã Pắc Ta,111
+3622,Xã Tà Mít,111
+3434,Thị trấn Nậm Nhùn,112
+3460,Xã Hua Bun,112
+3472,Xã Mường Mô,112
+3473,Xã Nậm Chà,112
+3474,Xã Nậm Manh,112
+3475,Xã Nậm Hàng,112
+3481,Xã Lê Lợi,112
+3484,Xã Pú Đao,112
+3488,Xã Nậm Pì,112
+3502,Xã Nậm Ban,112
+3503,Xã Trung Chải,112
+3646,Phường Chiềng Lề,116
+3649,Phường Tô Hiệu,116
+3652,Phường Quyết Thắng,116
+3655,Phường Quyết Tâm,116
+3658,Xã Chiềng Cọ,116
+3661,Xã Chiềng Đen,116
+3664,Xã Chiềng Xôm,116
+3667,Phường Chiềng An,116
+3670,Phường Chiềng Cơi,116
+3673,Xã Chiềng Ngần,116
+3676,Xã Hua La,116
+3679,Phường Chiềng Sinh,116
+3682,Xã Mường Chiên,118
+3685,Xã Cà Nàng,118
+3688,Xã Chiềng Khay,118
+3694,Xã Mường Giôn,118
+3697,Xã Pá Ma Pha Khinh,118
+3700,Xã Chiềng Ơn,118
+3703,Xã Mường Giàng,118
+3706,Xã Chiềng Bằng,118
+3709,Xã Mường Sại,118
+3712,Xã Nậm ét,118
+3718,Xã Chiềng Khoang,118
+3721,Thị trấn Thuận Châu,119
+3724,Xã Phổng Lái,119
+3727,Xã Mường é,119
+3730,Xã Chiềng Pha,119
+3733,Xã Chiềng La,119
+3736,Xã Chiềng Ngàm,119
+3739,Xã Liệp Tè,119
+3742,Xã é Tòng,119
+3745,Xã Phổng Lập,119
+3748,Xã Phổng Lăng,119
+3751,Xã Chiềng Ly,119
+3754,Xã Noong Lay,119
+3757,Xã Mường Khiêng,119
+3760,Xã Mường Bám,119
+3763,Xã Long Hẹ,119
+3766,Xã Chiềng Bôm,119
+3769,Xã Thôm Mòn,119
+3772,Xã Tông Lạnh,119
+3775,Xã Tông Cọ,119
+3778,Xã Bó Mười,119
+3781,Xã Co Mạ,119
+3784,Xã Púng Tra,119
+3787,Xã Chiềng Pấc,119
+3790,Xã Nậm Lầu,119
+3793,Xã Bon Phặng,119
+3796,Xã Co Tòng,119
+3799,Xã Muổi Nọi,119
+3802,Xã Pá Lông,119
+3805,Xã Bản Lầm,119
+3808,Thị trấn Ít Ong,120
+3811,Xã Nậm Giôn,120
+3814,Xã Chiềng Lao,120
+3817,Xã Hua Trai,120
+3820,Xã Ngọc Chiến,120
+3823,Xã Mường Trai,120
+3826,Xã Nậm Păm,120
+3829,Xã Chiềng Muôn,120
+3832,Xã Chiềng Ân,120
+3835,Xã Pi Toong,120
+3838,Xã Chiềng Công,120
+3841,Xã Tạ Bú,120
+3844,Xã Chiềng San,120
+3847,Xã Mường Bú,120
+3850,Xã Chiềng Hoa,120
+3853,Xã Mường Chùm,120
+3856,Thị trấn Bắc Yên,121
+3859,Xã Phiêng Ban,121
+3862,Xã Hang Chú,121
+3865,Xã Xím Vàng,121
+3868,Xã Tà Xùa,121
+3869,Xã Háng Đồng,121
+3871,Xã Pắc Ngà,121
+3874,Xã Làng Chếu,121
+3877,Xã Chim Vàn,121
+3880,Xã Mường Khoa,121
+3883,Xã Song Pe,121
+3886,Xã Hồng Ngài,121
+3889,Xã Tạ Khoa,121
+3890,Xã Hua Nhàn,121
+3892,Xã Phiêng Côn,121
+3895,Xã Chiềng Sại,121
+3898,Thị trấn Phù Yên,122
+3901,Xã Suối Tọ,122
+3904,Xã Mường Thải,122
+3907,Xã Mường Cơi,122
+3910,Xã Quang Huy,122
+3913,Xã Huy Bắc,122
+3916,Xã Huy Thượng,122
+3919,Xã Tân Lang,122
+3922,Xã Gia Phù,122
+3925,Xã Tường Phù,122
+3928,Xã Huy Hạ,122
+3931,Xã Huy Tân,122
+3934,Xã Mường Lang,122
+3937,Xã Suối Bau,122
+3940,Xã Huy Tường,122
+3943,Xã Mường Do,122
+3946,Xã Sập Xa,122
+3949,Xã Tường Thượng,122
+3952,Xã Tường Tiến,122
+3955,Xã Tường Phong,122
+3958,Xã Tường Hạ,122
+3961,Xã Kim Bon,122
+3964,Xã Mường Bang,122
+3967,Xã Đá Đỏ,122
+3970,Xã Tân Phong,122
+3973,Xã Nam Phong,122
+3976,Xã Bắc Phong,122
+3979,Thị trấn Mộc Châu,123
+3982,Thị trấn NT Mộc Châu,123
+3985,Xã Chiềng Sơn,123
+3988,Xã Tân Hợp,123
+3991,Xã Qui Hướng,123
+3997,Xã Tân Lập,123
+4000,Xã Nà Mường,123
+4003,Xã Tà Lai,123
+4012,Xã Chiềng Hắc,123
+4015,Xã Hua Păng,123
+4024,Xã Chiềng Khừa,123
+4027,Xã Mường Sang,123
+4030,Xã Đông Sang,123
+4033,Xã Phiêng Luông,123
+4045,Xã Lóng Sập,123
+4060,Thị trấn Yên Châu,124
+4063,Xã Chiềng Đông,124
+4066,Xã Sập Vạt,124
+4069,Xã Chiềng Sàng,124
+4072,Xã Chiềng Pằn,124
+4075,Xã Viêng Lán,124
+4078,Xã Chiềng Hặc,124
+4081,Xã Mường Lựm,124
+4084,Xã Chiềng On,124
+4087,Xã Yên Sơn,124
+4090,Xã Chiềng Khoi,124
+4093,Xã Tú Nang,124
+4096,Xã Lóng Phiêng,124
+4099,Xã Phiêng Khoài,124
+4102,Xã Chiềng Tương,124
+4105,Thị trấn Hát Lót,125
+4108,Xã Chiềng Sung,125
+4111,Xã Mường Bằng,125
+4114,Xã Chiềng Chăn,125
+4117,Xã Mương Chanh,125
+4120,Xã Chiềng Ban,125
+4123,Xã Chiềng Mung,125
+4126,Xã Mường Bon,125
+4129,Xã Chiềng Chung,125
+4132,Xã Chiềng Mai,125
+4135,Xã Hát Lót,125
+4136,Xã Nà Pó,125
+4138,Xã Cò  Nòi,125
+4141,Xã Chiềng Nơi,125
+4144,Xã Phiêng Cằm,125
+4147,Xã Chiềng Dong,125
+4150,Xã Chiềng Kheo,125
+4153,Xã Chiềng Ve,125
+4156,Xã Chiềng Lương,125
+4159,Xã Phiêng Pằn,125
+4162,Xã Nà Ơt,125
+4165,Xã Tà Hộc,125
+4168,Thị trấn Sông Mã,126
+4171,Xã Bó Sinh,126
+4174,Xã Pú Pẩu,126
+4177,Xã Chiềng Phung,126
+4180,Xã Chiềng En,126
+4183,Xã Mường Lầm,126
+4186,Xã Nậm Ty,126
+4189,Xã Đứa Mòn,126
+4192,Xã Yên Hưng,126
+4195,Xã Chiềng Sơ,126
+4198,Xã Nà Nghịu,126
+4201,Xã Nậm Mằn,126
+4204,Xã Chiềng Khoong,126
+4207,Xã Chiềng Cang,126
+4210,Xã Huổi Một,126
+4213,Xã Mường Sai,126
+4216,Xã Mường Cai,126
+4219,Xã Mường Hung,126
+4222,Xã Chiềng Khương,126
+4225,Xã Sam Kha,127
+4228,Xã Púng Bánh,127
+4231,Xã Sốp Cộp,127
+4234,Xã Dồm Cang,127
+4237,Xã Nậm Lạnh,127
+4240,Xã Mường Lèo,127
+4243,Xã Mường Và,127
+4246,Xã Mường Lạn,127
+3994,Xã Suối Bàng,128
+4006,Xã Song Khủa,128
+4009,Xã Liên Hoà,128
+4018,Xã Tô Múa,128
+4021,Xã Mường Tè,128
+4036,Xã Chiềng Khoa,128
+4039,Xã Mường Men,128
+4042,Xã Quang Minh,128
+4048,Xã Vân Hồ,128
+4051,Xã Lóng Luông,128
+4054,Xã Chiềng Yên,128
+4056,Xã Chiềng Xuân,128
+4057,Xã Xuân Nha,128
+4058,Xã Tân Xuân,128
+4249,Phường Yên Thịnh,132
+4252,Phường Yên Ninh,132
+4255,Phường Minh Tân,132
+4258,Phường Nguyễn Thái Học,132
+4261,Phường Đồng Tâm,132
+4264,Phường Nguyễn Phúc,132
+4267,Phường Hồng Hà,132
+4270,Xã Minh Bảo,132
+4273,Phường Nam Cường,132
+4276,Xã Tuy Lộc,132
+4279,Xã Tân Thịnh,132
+4540,Xã Âu Lâu,132
+4543,Xã Giới Phiên,132
+4546,Phường Hợp Minh,132
+4558,Xã Văn Phú,132
+4282,Phường Pú Trạng,133
+4285,Phường Trung Tâm,133
+4288,Phường Tân An,133
+4291,Phường Cầu Thia,133
+4294,Xã Nghĩa Lợi,133
+4297,Xã Nghĩa Phúc,133
+4300,Xã Nghĩa An,133
+4624,Xã Nghĩa Lộ,133
+4660,Xã Sơn A,133
+4663,Xã Phù Nham,133
+4675,Xã Thanh Lương,133
+4678,Xã Hạnh Sơn,133
+4681,Xã Phúc Sơn,133
+4684,Xã Thạch Lương,133
+4303,Thị trấn Yên Thế,135
+4306,Xã Tân Phượng,135
+4309,Xã Lâm Thượng,135
+4312,Xã Khánh Thiện,135
+4315,Xã Minh Chuẩn,135
+4318,Xã Mai Sơn,135
+4321,Xã Khai Trung,135
+4324,Xã Mường Lai,135
+4327,Xã An Lạc,135
+4330,Xã Minh Xuân,135
+4333,Xã Tô Mậu,135
+4336,Xã Tân Lĩnh,135
+4339,Xã Yên Thắng,135
+4342,Xã Khánh Hoà,135
+4345,Xã Vĩnh Lạc,135
+4348,Xã Liễu Đô,135
+4351,Xã Động Quan,135
+4354,Xã Tân Lập,135
+4357,Xã Minh Tiến,135
+4360,Xã Trúc Lâu,135
+4363,Xã Phúc Lợi,135
+4366,Xã Phan Thanh,135
+4369,Xã An Phú,135
+4372,Xã Trung Tâm,135
+4375,Thị trấn Mậu A,136
+4378,Xã Lang Thíp,136
+4381,Xã Lâm Giang,136
+4384,Xã Châu Quế Thượng,136
+4387,Xã Châu Quế Hạ,136
+4390,Xã An Bình,136
+4393,Xã Quang Minh,136
+4396,Xã Đông An,136
+4399,Xã Đông Cuông,136
+4402,Xã Phong Dụ Hạ,136
+4405,Xã Mậu Đông,136
+4408,Xã Ngòi A,136
+4411,Xã Xuân Tầm,136
+4414,Xã Tân Hợp,136
+4417,Xã An Thịnh,136
+4420,Xã Yên Thái,136
+4423,Xã Phong Dụ Thượng,136
+4426,Xã Yên Hợp,136
+4429,Xã Đại Sơn,136
+4435,Xã Đại Phác,136
+4438,Xã Yên Phú,136
+4441,Xã Xuân Ái,136
+4447,Xã Viễn Sơn,136
+4450,Xã Mỏ Vàng,136
+4453,Xã Nà Hẩu,136
+4456,Thị trấn Mù Căng Chải,137
+4459,Xã Hồ Bốn,137
+4462,Xã Nậm Có,137
+4465,Xã Khao Mang,137
+4468,Xã Mồ Dề,137
+4471,Xã Chế Cu Nha,137
+4474,Xã Lao Chải,137
+4477,Xã Kim Nọi,137
+4480,Xã Cao Phạ,137
+4483,Xã La Pán Tẩn,137
+4486,Xã Dế Su Phình,137
+4489,Xã Chế Tạo,137
+4492,Xã Púng Luông,137
+4495,Xã Nậm Khắt,137
+4498,Thị trấn Cổ Phúc,138
+4501,Xã Tân Đồng,138
+4504,Xã Báo Đáp,138
+4507,Xã Đào Thịnh,138
+4510,Xã Việt Thành,138
+4513,Xã Hòa Cuông,138
+4516,Xã Minh Quán,138
+4519,Xã Quy Mông,138
+4522,Xã Cường Thịnh,138
+4525,Xã Kiên Thành,138
+4528,Xã Nga Quán,138
+4531,Xã Y Can,138
+4537,Xã Lương Thịnh,138
+4561,Xã Bảo Hưng,138
+4564,Xã Việt Cường,138
+4567,Xã Minh Quân,138
+4570,Xã Hồng Ca,138
+4573,Xã Hưng Thịnh,138
+4576,Xã Hưng Khánh,138
+4579,Xã Việt Hồng,138
+4582,Xã Vân Hội,138
+4585,Thị trấn Trạm Tấu,139
+4588,Xã Túc Đán,139
+4591,Xã Pá Lau,139
+4594,Xã Xà Hồ,139
+4597,Xã Phình Hồ,139
+4600,Xã Trạm Tấu,139
+4603,Xã Tà Si Láng,139
+4606,Xã Pá Hu,139
+4609,Xã Làng Nhì,139
+4612,Xã Bản Công,139
+4615,Xã Bản Mù,139
+4618,Xã Hát Lìu,139
+4621,Thị trấn NT Liên Sơn,140
+4627,Thị trấn NT Trần Phú,140
+4630,Xã Tú Lệ,140
+4633,Xã Nậm Búng,140
+4636,Xã Gia Hội,140
+4639,Xã Sùng Đô,140
+4642,Xã Nậm Mười,140
+4645,Xã An Lương,140
+4648,Xã Nậm Lành,140
+4651,Xã Sơn Lương,140
+4654,Xã Suối Quyền,140
+4657,Xã Suối Giàng,140
+4666,Xã Nghĩa Sơn,140
+4669,Xã Suối Bu,140
+4672,Thị trấn Sơn Thịnh,140
+4687,Xã Đại Lịch,140
+4690,Xã Đồng Khê,140
+4693,Xã Cát Thịnh,140
+4696,Xã Tân Thịnh,140
+4699,Xã Chấn Thịnh,140
+4702,Xã Bình Thuận,140
+4705,Xã Thượng Bằng La,140
+4708,Xã Minh An,140
+4711,Xã Nghĩa Tâm,140
+4714,Thị trấn Yên Bình,141
+4717,Thị trấn Thác Bà,141
+4720,Xã Xuân Long,141
+4726,Xã Cảm Nhân,141
+4729,Xã Ngọc Chấn,141
+4732,Xã Tân Nguyên,141
+4735,Xã Phúc Ninh,141
+4738,Xã Bảo Ái,141
+4741,Xã Mỹ Gia,141
+4744,Xã Xuân Lai,141
+4747,Xã Mông Sơn,141
+4750,Xã Cảm Ân,141
+4753,Xã Yên Thành,141
+4756,Xã Tân Hương,141
+4759,Xã Phúc An,141
+4762,Xã Bạch Hà,141
+4765,Xã Vũ Linh,141
+4768,Xã Đại Đồng,141
+4771,Xã Vĩnh Kiên,141
+4774,Xã Yên Bình,141
+4777,Xã Thịnh Hưng,141
+4780,Xã Hán Đà,141
+4783,Xã Phú Thịnh,141
+4786,Xã Đại Minh,141
+4789,Phường Thái Bình,148
+4792,Phường Tân Hòa,148
+4795,Phường Thịnh Lang,148
+4798,Phường Hữu Nghị,148
+4801,Phường Tân Thịnh,148
+4804,Phường Đồng Tiến,148
+4807,Phường Phương Lâm,148
+4813,Xã Yên Mông,148
+4816,Phường Quỳnh Lâm,148
+4819,Phường Dân Chủ,148
+4825,Xã Hòa Bình,148
+4828,Phường Thống Nhất,148
+4894,Phường Kỳ Sơn,148
+4897,Xã Thịnh Minh,148
+4903,Xã Hợp Thành,148
+4906,Xã Quang Tiến,148
+4912,Xã Mông Hóa,148
+4918,Phường Trung Minh,148
+4921,Xã Độc Lập,148
+4831,Thị trấn Đà Bắc,150
+4834,Xã Nánh Nghê,150
+4840,Xã Giáp Đắt,150
+4846,Xã Mường Chiềng,150
+4849,Xã Tân Pheo,150
+4852,Xã Đồng Chum,150
+4855,Xã Tân Minh,150
+4858,Xã Đoàn Kết,150
+4861,Xã Đồng Ruộng,150
+4867,Xã Tú Lý,150
+4870,Xã Trung Thành,150
+4873,Xã Yên Hòa,150
+4876,Xã Cao Sơn,150
+4879,Xã Toàn Sơn,150
+4885,Xã Hiền Lương,150
+4888,Xã Tiền Phong,150
+4891,Xã Vầy Nưa,150
+4924,Thị trấn Lương Sơn,152
+4942,Xã Lâm Sơn,152
+4945,Xã Hòa Sơn,152
+4951,Xã Tân Vinh,152
+4954,Xã Nhuận Trạch,152
+4957,Xã Cao Sơn,152
+4960,Xã Cư Yên,152
+4969,Xã Liên Sơn,152
+5008,Xã Cao Dương,152
+5041,Xã Thanh Sơn,152
+5047,Xã Thanh Cao,152
+4978,Thị trấn Bo,153
+4984,Xã Đú Sáng,153
+4987,Xã Hùng Sơn,153
+4990,Xã Bình Sơn,153
+4999,Xã Tú Sơn,153
+5005,Xã Vĩnh Tiến,153
+5014,Xã Đông Bắc,153
+5017,Xã Xuân Thủy,153
+5026,Xã Vĩnh Đồng,153
+5035,Xã Kim Lập,153
+5038,Xã Hợp Tiến,153
+5065,Xã Kim Bôi,153
+5068,Xã Nam Thượng,153
+5077,Xã Cuối Hạ,153
+5080,Xã Sào Báy,153
+5083,Xã Mi Hòa,153
+5086,Xã Nuông Dăm,153
+5089,Thị trấn Cao Phong,154
+5092,Xã Bình Thanh,154
+5095,Xã Thung Nai,154
+5098,Xã Bắc Phong,154
+5101,Xã Thu Phong,154
+5104,Xã Hợp Phong,154
+5110,Xã Tây Phong,154
+5116,Xã Dũng Phong,154
+5119,Xã Nam Phong,154
+5125,Xã Thạch Yên,154
+5128,Thị trấn Mãn Đức,155
+5134,Xã Suối Hoa,155
+5137,Xã Phú Vinh,155
+5140,Xã Phú Cường,155
+5143,Xã Mỹ Hòa,155
+5152,Xã Quyết Chiến,155
+5158,Xã Phong Phú,155
+5164,Xã Tử Nê,155
+5167,Xã Thanh Hối,155
+5170,Xã Ngọc Mỹ,155
+5173,Xã Đông Lai,155
+5176,Xã Vân Sơn,155
+5182,Xã Nhân Mỹ,155
+5191,Xã Lỗ Sơn,155
+5194,Xã Ngổ Luông,155
+5197,Xã Gia Mô,155
+4882,Xã Tân Thành,156
+5200,Thị trấn Mai Châu,156
+5206,Xã Sơn Thủy,156
+5209,Xã Pà Cò,156
+5212,Xã Hang Kia,156
+5221,Xã Đồng Tân,156
+5224,Xã Cun Pheo,156
+5227,Xã Bao La,156
+5233,Xã Tòng Đậu,156
+5242,Xã Nà Phòn,156
+5245,Xã Săm Khóe,156
+5248,Xã Chiềng Châu,156
+5251,Xã Mai Hạ,156
+5254,Xã Thành Sơn,156
+5257,Xã Mai Hịch,156
+5263,Xã Vạn Mai,156
+5266,Thị trấn Vụ Bản,157
+5269,Xã Quý Hòa,157
+5272,Xã Miền Đồi,157
+5275,Xã Mỹ Thành,157
+5278,Xã Tuân Đạo,157
+5281,Xã Văn Nghĩa,157
+5284,Xã Văn Sơn,157
+5287,Xã Tân Lập,157
+5290,Xã Nhân Nghĩa,157
+5293,Xã Thượng Cốc,157
+5299,Xã Quyết Thắng,157
+5302,Xã Xuất Hóa,157
+5305,Xã Yên Phú,157
+5308,Xã Bình Hẻm,157
+5320,Xã Định Cư,157
+5323,Xã Chí Đạo,157
+5329,Xã Ngọc Sơn,157
+5332,Xã Hương Nhượng,157
+5335,Xã Vũ Bình,157
+5338,Xã Tự Do,157
+5341,Xã Yên Nghiệp,157
+5344,Xã Tân Mỹ,157
+5347,Xã Ân Nghĩa,157
+5350,Xã Ngọc Lâu,157
+5353,Thị trấn Hàng Trạm,158
+5356,Xã Lạc Sỹ,158
+5362,Xã Lạc Lương,158
+5365,Xã Bảo Hiệu,158
+5368,Xã Đa Phúc,158
+5371,Xã Hữu Lợi,158
+5374,Xã Lạc Thịnh,158
+5380,Xã Đoàn Kết,158
+5383,Xã Phú Lai,158
+5386,Xã Yên Trị,158
+5389,Xã Ngọc Lương,158
+4981,Thị trấn Ba Hàng Đồi,159
+5392,Thị trấn Chi Nê,159
+5395,Xã Phú Nghĩa,159
+5398,Xã Phú Thành,159
+5404,Xã Hưng Thi,159
+5413,Xã Khoan Dụ,159
+5419,Xã Đồng Tâm,159
+5422,Xã Yên Bồng,159
+5425,Xã Thống Nhất,159
+5428,Xã An Bình,159
+5431,Phường Quán Triều,164
+5434,Phường Quang Vinh,164
+5437,Phường Túc Duyên,164
+5440,Phường Hoàng Văn Thụ,164
+5443,Phường Trưng Vương,164
+5446,Phường Quang Trung,164
+5449,Phường Phan Đình Phùng,164
+5452,Phường Tân Thịnh,164
+5455,Phường Thịnh Đán,164
+5458,Phường Đồng Quang,164
+5461,Phường Gia Sàng,164
+5464,Phường Tân Lập,164
+5467,Phường Cam Giá,164
+5470,Phường Phú Xá,164
+5473,Phường Hương Sơn,164
+5476,Phường Trung Thành,164
+5479,Phường Tân Thành,164
+5482,Phường Tân Long,164
+5485,Xã Phúc Hà,164
+5488,Xã Phúc Xuân,164
+5491,Xã Quyết Thắng,164
+5494,Xã Phúc Trìu,164
+5497,Xã Thịnh Đức,164
+5500,Phường Tích Lương,164
+5503,Xã Tân Cương,164
+5653,Xã Sơn Cẩm,164
+5659,Phường Chùa Hang,164
+5695,Xã Cao Ngạn,164
+5701,Xã Linh Sơn,164
+5710,Phường Đồng Bẩm,164
+5713,Xã Huống Thượng,164
+5914,Xã Đồng Liên,164
+5506,Phường Lương Sơn,165
+5509,Phường Châu Sơn,165
+5512,Phường Mỏ Chè,165
+5515,Phường Cải Đan,165
+5518,Phường Thắng Lợi,165
+5521,Phường Phố Cò,165
+5527,Xã Tân Quang,165
+5528,Phường Bách Quang,165
+5530,Xã Bình Sơn,165
+5533,Xã Bá Xuyên,165
+5536,Thị trấn Chợ Chu,167
+5539,Xã Linh Thông,167
+5542,Xã Lam Vỹ,167
+5545,Xã Quy Kỳ,167
+5548,Xã Tân Thịnh,167
+5551,Xã Kim Phượng,167
+5554,Xã Bảo Linh,167
+5560,Xã Phúc Chu,167
+5563,Xã Tân Dương,167
+5566,Xã Phượng Tiến,167
+5569,Xã Bảo Cường,167
+5572,Xã Đồng Thịnh,167
+5575,Xã Định Biên,167
+5578,Xã Thanh Định,167
+5581,Xã Trung Hội,167
+5584,Xã Trung Lương,167
+5587,Xã Bình Yên,167
+5590,Xã Điềm Mặc,167
+5593,Xã Phú Tiến,167
+5596,Xã Bộc Nhiêu,167
+5599,Xã Sơn Phú,167
+5602,Xã Phú Đình,167
+5605,Xã Bình Thành,167
+5608,Thị trấn Giang Tiên,168
+5611,Thị trấn Đu,168
+5614,Xã Yên Ninh,168
+5617,Xã Yên Trạch,168
+5620,Xã Yên Đổ,168
+5623,Xã Yên Lạc,168
+5626,Xã Ôn Lương,168
+5629,Xã Động Đạt,168
+5632,Xã Phủ Lý,168
+5635,Xã Phú Đô,168
+5638,Xã Hợp Thành,168
+5641,Xã Tức Tranh,168
+5644,Xã Phấn Mễ,168
+5647,Xã Vô Tranh,168
+5650,Xã Cổ Lũng,168
+5656,Thị trấn Sông Cầu,169
+5662,Thị trấn Trại Cau,169
+5665,Xã Văn Lăng,169
+5668,Xã Tân Long,169
+5671,Xã Hòa Bình,169
+5674,Xã Quang Sơn,169
+5677,Xã Minh Lập,169
+5680,Xã Văn Hán,169
+5683,Xã Hóa Trung,169
+5686,Xã Khe Mo,169
+5689,Xã Cây Thị,169
+5692,Xã Hóa Thượng,169
+5698,Xã Hợp Tiến,169
+5704,Xã Tân Lợi,169
+5707,Xã Nam Hòa,169
+5716,Thị trấn Đình Cả,170
+5719,Xã Sảng Mộc,170
+5722,Xã Nghinh Tường,170
+5725,Xã Thần Xa,170
+5728,Xã Vũ Chấn,170
+5731,Xã Thượng Nung,170
+5734,Xã Phú Thượng,170
+5737,Xã Cúc Đường,170
+5740,Xã La Hiên,170
+5743,Xã Lâu Thượng,170
+5746,Xã Tràng Xá,170
+5749,Xã Phương Giao,170
+5752,Xã Liên Minh,170
+5755,Xã Dân Tiến,170
+5758,Xã Bình Long,170
+5761,Thị trấn Hùng Sơn,171
+5764,Thị trấn Quân Chu,171
+5767,Xã Phúc Lương,171
+5770,Xã Minh Tiến,171
+5773,Xã Yên Lãng,171
+5776,Xã Đức Lương,171
+5779,Xã Phú Cường,171
+5782,Xã Na Mao,171
+5785,Xã Phú Lạc,171
+5788,Xã Tân Linh,171
+5791,Xã Phú Thịnh,171
+5794,Xã Phục Linh,171
+5797,Xã Phú Xuyên,171
+5800,Xã Bản Ngoại,171
+5803,Xã Tiên Hội,171
+5809,Xã Cù Vân,171
+5812,Xã Hà Thượng,171
+5815,Xã La Bằng,171
+5818,Xã Hoàng Nông,171
+5821,Xã Khôi Kỳ,171
+5824,Xã An Khánh,171
+5827,Xã Tân Thái,171
+5830,Xã Bình Thuận,171
+5833,Xã Lục Ba,171
+5836,Xã Mỹ Yên,171
+5839,Xã Vạn Thọ,171
+5842,Xã Văn Yên,171
+5845,Xã Ký Phú,171
+5848,Xã Cát Nê,171
+5851,Xã Quân Chu,171
+5854,Phường Bãi Bông,172
+5857,Phường Bắc Sơn,172
+5860,Phường Ba Hàng,172
+5863,Xã Phúc Tân,172
+5866,Xã Phúc Thuận,172
+5869,Phường Hồng Tiến,172
+5872,Xã Minh Đức,172
+5875,Phường Đắc Sơn,172
+5878,Phường Đồng Tiến,172
+5881,Xã Thành Công,172
+5884,Phường Tiên Phong,172
+5887,Xã Vạn Phái,172
+5890,Phường Nam Tiến,172
+5893,Phường Tân Hương,172
+5896,Phường Đông Cao,172
+5899,Phường Trung Thành,172
+5902,Phường Tân Phú,172
+5905,Phường Thuận Thành,172
+5908,Thị trấn Hương Sơn,173
+5911,Xã Bàn Đạt,173
+5917,Xã Tân Khánh,173
+5920,Xã Tân Kim,173
+5923,Xã Tân Thành,173
+5926,Xã Đào Xá,173
+5929,Xã Bảo Lý,173
+5932,Xã Thượng Đình,173
+5935,Xã Tân Hòa,173
+5938,Xã Nhã Lộng,173
+5941,Xã Điềm Thụy,173
+5944,Xã Xuân Phương,173
+5947,Xã Tân Đức,173
+5950,Xã Úc Kỳ,173
+5953,Xã Lương Phú,173
+5956,Xã Nga My,173
+5959,Xã Kha Sơn,173
+5962,Xã Thanh Ninh,173
+5965,Xã Dương Thành,173
+5968,Xã Hà Châu,173
+5971,Phường Hoàng Văn Thụ,178
+5974,Phường Tam Thanh,178
+5977,Phường Vĩnh Trại,178
+5980,Phường Đông Kinh,178
+5983,Phường Chi Lăng,178
+5986,Xã Hoàng Đồng,178
+5989,Xã Quảng Lạc,178
+5992,Xã Mai Pha,178
+5995,Thị trấn Thất Khê,180
+5998,Xã Khánh Long,180
+6001,Xã Đoàn Kết,180
+6004,Xã Quốc Khánh,180
+6007,Xã Vĩnh Tiến,180
+6010,Xã Cao Minh,180
+6013,Xã Chí Minh,180
+6016,Xã Tri Phương,180
+6019,Xã Tân Tiến,180
+6022,Xã Tân Yên,180
+6025,Xã Đội Cấn,180
+6028,Xã Tân Minh,180
+6031,Xã Kim Đồng,180
+6034,Xã Chi Lăng,180
+6037,Xã Trung Thành,180
+6040,Xã Đại Đồng,180
+6043,Xã Đào Viên,180
+6046,Xã Đề Thám,180
+6049,Xã Kháng Chiến,180
+6055,Xã Hùng Sơn,180
+6058,Xã Quốc Việt,180
+6061,Xã Hùng Việt,180
+6067,Xã Hưng Đạo,181
+6070,Xã Vĩnh Yên,181
+6073,Xã Hoa Thám,181
+6076,Xã Quý Hòa,181
+6079,Xã Hồng Phong,181
+6082,Xã Yên Lỗ,181
+6085,Xã Thiện Hòa,181
+6088,Xã Quang Trung,181
+6091,Xã Thiện Thuật,181
+6094,Xã Minh Khai,181
+6097,Xã Thiện Long,181
+6100,Xã Hoàng Văn Thụ,181
+6103,Xã Hòa Bình,181
+6106,Xã Mông Ân,181
+6109,Xã Tân Hòa,181
+6112,Thị trấn Bình Gia,181
+6115,Xã Hồng Thái,181
+6118,Xã Bình La,181
+6121,Xã Tân Văn,181
+6124,Thị trấn Na Sầm,182
+6127,Xã Trùng Khánh,182
+6133,Xã Bắc La,182
+6136,Xã Thụy Hùng,182
+6139,Xã Bắc Hùng,182
+6142,Xã Tân Tác,182
+6148,Xã Thanh Long,182
+6151,Xã Hội Hoan,182
+6154,Xã Bắc Việt,182
+6157,Xã Hoàng Việt,182
+6160,Xã Gia Miễn,182
+6163,Xã Thành Hòa,182
+6166,Xã Tân Thanh,182
+6172,Xã Tân Mỹ,182
+6175,Xã Hồng Thái,182
+6178,Xã  Hoàng Văn Thụ,182
+6181,Xã Nhạc Kỳ,182
+6184,Thị trấn Đồng Đăng,183
+6187,Thị trấn Cao Lộc,183
+6190,Xã Bảo Lâm,183
+6193,Xã Thanh Lòa,183
+6196,Xã Cao Lâu,183
+6199,Xã Thạch Đạn,183
+6202,Xã Xuất Lễ,183
+6205,Xã Hồng Phong,183
+6208,Xã Thụy Hùng,183
+6211,Xã Lộc Yên,183
+6214,Xã Phú Xá,183
+6217,Xã Bình Trung,183
+6220,Xã Hải Yến,183
+6223,Xã Hòa Cư,183
+6226,Xã Hợp Thành,183
+6232,Xã Công Sơn,183
+6235,Xã Gia Cát,183
+6238,Xã Mẫu Sơn,183
+6241,Xã Xuân Long,183
+6244,Xã Tân Liên,183
+6247,Xã Yên Trạch,183
+6250,Xã Tân Thành,183
+6253,Thị trấn Văn Quan,184
+6256,Xã Trấn Ninh,184
+6268,Xã Liên Hội,184
+6274,Xã Hòa Bình,184
+6277,Xã Tú Xuyên,184
+6280,Xã Điềm He,184
+6283,Xã An Sơn,184
+6286,Xã Khánh Khê,184
+6292,Xã Lương Năng,184
+6295,Xã Đồng Giáp,184
+6298,Xã Bình Phúc,184
+6301,Xã Tràng Các,184
+6307,Xã Tân Đoàn,184
+6313,Xã Tri Lễ,184
+6316,Xã Tràng Phái,184
+6319,Xã Yên Phúc,184
+6322,Xã Hữu Lễ,184
+6325,Thị trấn Bắc Sơn,185
+6328,Xã Long Đống,185
+6331,Xã Vạn Thủy,185
+6337,Xã Đồng ý,185
+6340,Xã Tân Tri,185
+6343,Xã Bắc Quỳnh,185
+6349,Xã Hưng Vũ,185
+6352,Xã Tân Lập,185
+6355,Xã Vũ Sơn,185
+6358,Xã Chiêu Vũ,185
+6361,Xã Tân Hương,185
+6364,Xã Chiến Thắng,185
+6367,Xã Vũ Lăng,185
+6370,Xã Trấn Yên,185
+6373,Xã Vũ Lễ,185
+6376,Xã Nhất Hòa,185
+6379,Xã Tân Thành,185
+6382,Xã Nhất Tiến,185
+6385,Thị trấn Hữu Lũng,186
+6388,Xã Hữu Liên,186
+6391,Xã Yên Bình,186
+6394,Xã Quyết Thắng,186
+6397,Xã Hòa Bình,186
+6400,Xã Yên Thịnh,186
+6403,Xã Yên Sơn,186
+6406,Xã Thiện Tân,186
+6412,Xã Yên Vượng,186
+6415,Xã Minh Tiến,186
+6418,Xã Nhật Tiến,186
+6421,Xã Thanh Sơn,186
+6424,Xã Đồng Tân,186
+6427,Xã Cai Kinh,186
+6430,Xã Hòa Lạc,186
+6433,Xã Vân Nham,186
+6436,Xã Đồng Tiến,186
+6442,Xã Tân Thành,186
+6445,Xã Hòa Sơn,186
+6448,Xã Minh Sơn,186
+6451,Xã Hồ Sơn,186
+6454,Xã Sơn Hà,186
+6457,Xã Minh Hòa,186
+6460,Xã Hòa Thắng,186
+6463,Thị trấn Đồng Mỏ,187
+6466,Thị trấn Chi Lăng,187
+6469,Xã Vân An,187
+6472,Xã Vân Thủy,187
+6475,Xã Gia Lộc,187
+6478,Xã Bắc Thủy,187
+6481,Xã Chiến Thắng,187
+6484,Xã Mai Sao,187
+6487,Xã Bằng Hữu,187
+6490,Xã Thượng Cường,187
+6493,Xã Bằng Mạc,187
+6496,Xã Nhân Lý,187
+6499,Xã Lâm Sơn,187
+6502,Xã Liên Sơn,187
+6505,Xã Vạn Linh,187
+6508,Xã Hòa Bình,187
+6514,Xã Hữu Kiên,187
+6517,Xã Quan Sơn,187
+6520,Xã Y Tịch,187
+6523,Xã Chi Lăng,187
+6526,Thị trấn Na Dương,188
+6529,Thị trấn Lộc Bình,188
+6532,Xã Mẫu Sơn,188
+6541,Xã Yên Khoái,188
+6544,Xã Khánh Xuân,188
+6547,Xã Tú Mịch,188
+6550,Xã Hữu Khánh,188
+6553,Xã Đồng Bục,188
+6559,Xã Tam Gia,188
+6562,Xã Tú Đoạn,188
+6565,Xã Khuất Xá,188
+6574,Xã Tĩnh Bắc,188
+6577,Xã Thống Nhất,188
+6589,Xã Sàn Viên,188
+6592,Xã Đông Quan,188
+6595,Xã Minh Hiệp,188
+6598,Xã Hữu Lân,188
+6601,Xã Lợi Bác,188
+6604,Xã Nam Quan,188
+6607,Xã Xuân Dương,188
+6610,Xã Ái Quốc,188
+6613,Thị trấn Đình Lập,189
+6616,Thị trấn NT Thái Bình,189
+6619,Xã Bắc Xa,189
+6622,Xã Bính Xá,189
+6625,Xã Kiên Mộc,189
+6628,Xã Đình Lập,189
+6631,Xã Thái Bình,189
+6634,Xã Cường Lợi,189
+6637,Xã Châu Sơn,189
+6640,Xã Lâm Ca,189
+6643,Xã Đồng Thắng,189
+6646,Xã Bắc Lãng,189
+6649,Phường Hà Khánh,193
+6652,Phường Hà Phong,193
+6655,Phường Hà Khẩu,193
+6658,Phường Cao Xanh,193
+6661,Phường Giếng Đáy,193
+6664,Phường Hà Tu,193
+6667,Phường Hà Trung,193
+6670,Phường Hà Lầm,193
+6673,Phường Bãi Cháy,193
+6676,Phường Cao Thắng,193
+6679,Phường Hùng Thắng,193
+6682,Phường Yết Kiêu,193
+6685,Phường Trần Hưng Đạo,193
+6688,Phường Hồng Hải,193
+6691,Phường Hồng Gai,193
+6694,Phường Bạch Đằng,193
+6697,Phường Hồng Hà,193
+6700,Phường Tuần Châu,193
+6703,Phường Việt Hưng,193
+6706,Phường Đại Yên,193
+7030,Phường Hoành Bồ,193
+7033,Xã Kỳ Thượng,193
+7036,Xã Đồng Sơn,193
+7039,Xã Tân Dân,193
+7042,Xã Đồng Lâm,193
+7045,Xã Hòa Bình,193
+7048,Xã Vũ Oai,193
+7051,Xã Dân Chủ,193
+7054,Xã Quảng La,193
+7057,Xã Bằng Cả,193
+7060,Xã Thống Nhất,193
+7063,Xã Sơn Dương,193
+7066,Xã Lê Lợi,193
+6709,Phường Ka Long,194
+6712,Phường Trần Phú,194
+6715,Phường Ninh Dương,194
+6718,Phường Hoà Lạc,194
+6721,Phường Trà Cổ,194
+6724,Xã Hải Sơn,194
+6727,Xã Bắc Sơn,194
+6730,Xã Hải Đông,194
+6733,Xã Hải Tiến,194
+6736,Phường Hải Yên,194
+6739,Xã Quảng Nghĩa,194
+6742,Phường Hải Hoà,194
+6745,Xã Hải Xuân,194
+6748,Xã Vạn Ninh,194
+6751,Phường Bình Ngọc,194
+6754,Xã Vĩnh Trung,194
+6757,Xã Vĩnh Thực,194
+6760,Phường Mông Dương,195
+6763,Phường Cửa Ông,195
+6766,Phường Cẩm Sơn,195
+6769,Phường Cẩm Đông,195
+6772,Phường Cẩm Phú,195
+6775,Phường Cẩm Tây,195
+6778,Phường Quang Hanh,195
+6781,Phường Cẩm Thịnh,195
+6784,Phường Cẩm Thủy,195
+6787,Phường Cẩm Thạch,195
+6790,Phường Cẩm Thành,195
+6793,Phường Cẩm Trung,195
+6796,Phường Cẩm Bình,195
+6799,Xã Cộng Hòa,195
+6802,Xã Cẩm Hải,195
+6805,Xã Dương Huy,195
+6808,Phường Vàng Danh,196
+6811,Phường Thanh Sơn,196
+6814,Phường Bắc Sơn,196
+6817,Phường Quang Trung,196
+6820,Phường Trưng Vương,196
+6823,Phường Nam Khê,196
+6826,Phường Yên Thanh,196
+6829,Xã Thượng Yên Công,196
+6832,Phường Phương Đông,196
+6835,Phường Phương Nam,196
+6838,Thị trấn Bình Liêu,198
+6841,Xã Hoành Mô,198
+6844,Xã Đồng Tâm,198
+6847,Xã Đồng Văn,198
+6853,Xã Vô Ngại,198
+6856,Xã Lục Hồn,198
+6859,Xã Húc Động,198
+6862,Thị trấn Tiên Yên,199
+6865,Xã Hà Lâu,199
+6868,Xã Đại Dực,199
+6871,Xã Phong Dụ,199
+6874,Xã Điền Xá,199
+6877,Xã Đông Ngũ,199
+6880,Xã Yên Than,199
+6883,Xã Đông Hải,199
+6886,Xã Hải Lạng,199
+6889,Xã Tiên Lãng,199
+6892,Xã Đồng Rui,199
+6895,Thị trấn Đầm Hà,200
+6898,Xã Quảng Lâm,200
+6901,Xã Quảng An,200
+6904,Xã Tân Bình,200
+6910,Xã Dực Yên,200
+6913,Xã Quảng Tân,200
+6916,Xã Đầm Hà,200
+6917,Xã Tân Lập,200
+6919,Xã Đại Bình,200
+6922,Thị trấn Quảng Hà,201
+6925,Xã Quảng Đức,201
+6928,Xã Quảng Sơn,201
+6931,Xã Quảng Thành,201
+6937,Xã Quảng Thịnh,201
+6940,Xã Quảng Minh,201
+6943,Xã Quảng Chính,201
+6946,Xã Quảng Long,201
+6949,Xã Đường Hoa,201
+6952,Xã Quảng Phong,201
+6967,Xã Cái Chiên,201
+6970,Thị trấn Ba Chẽ,202
+6973,Xã Thanh Sơn,202
+6976,Xã Thanh Lâm,202
+6979,Xã Đạp Thanh,202
+6982,Xã Nam Sơn,202
+6985,Xã Lương Mông,202
+6988,Xã Đồn Đạc,202
+6991,Xã Minh Cầm,202
+6994,Thị trấn Cái Rồng,203
+6997,Xã Đài Xuyên,203
+7000,Xã Bình Dân,203
+7003,Xã Vạn Yên,203
+7006,Xã Minh Châu,203
+7009,Xã Đoàn Kết,203
+7012,Xã Hạ Long,203
+7015,Xã Đông Xá,203
+7018,Xã Bản Sen,203
+7021,Xã Thắng Lợi,203
+7024,Xã Quan Lạn,203
+7027,Xã Ngọc Vừng,203
+7069,Phường Mạo Khê,205
+7072,Phường Đông Triều,205
+7075,Xã An Sinh,205
+7078,Xã Tràng Lương,205
+7081,Xã Bình Khê,205
+7084,Xã Việt Dân,205
+7087,Xã Tân Việt,205
+7090,Xã Bình Dương,205
+7093,Phường Đức Chính,205
+7096,Phường Tràng An,205
+7099,Xã Nguyễn Huệ,205
+7102,Xã Thủy An,205
+7105,Phường Xuân Sơn,205
+7108,Xã Hồng Thái Tây,205
+7111,Xã Hồng Thái Đông,205
+7114,Phường Hoàng Quế,205
+7117,Phường Yên Thọ,205
+7120,Phường Hồng Phong,205
+7123,Phường Kim Sơn,205
+7126,Phường Hưng Đạo,205
+7129,Xã Yên Đức,205
+7132,Phường Quảng Yên,206
+7135,Phường Đông Mai,206
+7138,Phường Minh Thành,206
+7144,Xã Sông Khoai,206
+7147,Xã Hiệp Hòa,206
+7150,Phường Cộng Hòa,206
+7153,Xã Tiền An,206
+7156,Xã Hoàng Tân,206
+7159,Phường Tân An,206
+7162,Phường Yên Giang,206
+7165,Phường Nam Hoà,206
+7168,Phường Hà An,206
+7171,Xã Cẩm La,206
+7174,Phường Phong Hải,206
+7177,Phường Yên Hải,206
+7180,Xã Liên Hòa,206
+7183,Phường Phong Cốc,206
+7186,Xã Liên Vị,206
+7189,Xã Tiền Phong,206
+7192,Thị trấn Cô Tô,207
+7195,Xã Đồng Tiến,207
+7198,Xã Thanh Lân,207
+7201,Phường Thọ Xương,213
+7204,Phường Trần Nguyên Hãn,213
+7207,Phường Ngô Quyền,213
+7210,Phường Hoàng Văn Thụ,213
+7213,Phường Trần Phú,213
+7216,Phường Mỹ Độ,213
+7219,Phường Lê Lợi,213
+7222,Xã Song Mai,213
+7225,Phường Xương Giang,213
+7228,Phường Đa Mai,213
+7231,Phường Dĩnh Kế,213
+7441,Xã Dĩnh Trì,213
+7687,Xã Tân Mỹ,213
+7696,Xã Đồng Sơn,213
+7699,Xã Tân Tiến,213
+7705,Xã Song Khê,213
+7243,Xã Đồng Tiến,215
+7246,Xã Canh Nậu,215
+7249,Xã Xuân Lương,215
+7252,Xã Tam Tiến,215
+7255,Xã Đồng Vương,215
+7258,Xã Đồng Hưu,215
+7260,Xã Đồng Tâm,215
+7261,Xã Tam Hiệp,215
+7264,Xã Tiến Thắng,215
+7267,Xã Hồng Kỳ,215
+7270,Xã Đồng Lạc,215
+7273,Xã Đông Sơn,215
+7276,Xã Tân Hiệp,215
+7279,Xã Hương Vĩ,215
+7282,Xã Đồng Kỳ,215
+7285,Xã An Thượng,215
+7288,Thị trấn Phồn Xương,215
+7291,Xã Tân Sỏi,215
+7294,Thị trấn Bố Hạ,215
+7303,Xã Lan Giới,216
+7306,Thị trấn Nhã Nam,216
+7309,Xã Tân Trung,216
+7312,Xã Đại Hóa,216
+7315,Xã Quang Tiến,216
+7318,Xã Phúc Sơn,216
+7321,Xã An Dương,216
+7324,Xã Phúc Hòa,216
+7327,Xã Liên Sơn,216
+7330,Xã Hợp Đức,216
+7333,Xã Lam Cốt,216
+7336,Xã Cao Xá,216
+7339,Thị trấn Cao Thượng,216
+7342,Xã Việt Ngọc,216
+7345,Xã Song Vân,216
+7348,Xã Ngọc Châu,216
+7351,Xã Ngọc Vân,216
+7354,Xã Việt Lập,216
+7357,Xã Liên Chung,216
+7360,Xã Ngọc Thiện,216
+7363,Xã Ngọc Lý,216
+7366,Xã Quế Nham,216
+7375,Thị trấn Vôi,217
+7378,Xã Nghĩa Hòa,217
+7381,Xã Nghĩa Hưng,217
+7384,Xã Quang Thịnh,217
+7387,Xã Hương Sơn,217
+7390,Xã Đào Mỹ,217
+7393,Xã Tiên Lục,217
+7396,Xã An Hà,217
+7399,Thị trấn Kép,217
+7402,Xã Mỹ Hà,217
+7405,Xã Hương Lạc,217
+7408,Xã Dương Đức,217
+7411,Xã Tân Thanh,217
+7414,Xã Yên Mỹ,217
+7417,Xã Tân Hưng,217
+7420,Xã Mỹ Thái,217
+7426,Xã Xương Lâm,217
+7429,Xã Xuân Hương,217
+7432,Xã Tân Dĩnh,217
+7435,Xã Đại Lâm,217
+7438,Xã Thái Đào,217
+7444,Thị trấn Đồi Ngô,218
+7450,Xã Đông Hưng,218
+7453,Xã Đông Phú,218
+7456,Xã Tam Dị,218
+7459,Xã Bảo Sơn,218
+7462,Xã Bảo Đài,218
+7465,Xã Thanh Lâm,218
+7468,Xã Tiên Nha,218
+7471,Xã Trường Giang,218
+7477,Thị trấn Phương Sơn,218
+7480,Xã Chu Điện,218
+7483,Xã Cương Sơn,218
+7486,Xã Nghĩa Phương,218
+7489,Xã Vô Tranh,218
+7492,Xã Bình Sơn,218
+7495,Xã Lan Mẫu,218
+7498,Xã Yên Sơn,218
+7501,Xã Khám Lạng,218
+7504,Xã Huyền Sơn,218
+7507,Xã Trường Sơn,218
+7510,Xã Lục Sơn,218
+7513,Xã Bắc Lũng,218
+7516,Xã Vũ Xá,218
+7519,Xã Cẩm Lý,218
+7522,Xã Đan Hội,218
+7525,Thị trấn Chũ,219
+7528,Xã Cấm Sơn,219
+7531,Xã Tân Sơn,219
+7534,Xã Phong Minh,219
+7537,Xã Phong Vân,219
+7540,Xã Xa Lý,219
+7543,Xã Hộ Đáp,219
+7546,Xã Sơn Hải,219
+7549,Xã Thanh Hải,219
+7552,Xã Kiên Lao,219
+7555,Xã Biên Sơn,219
+7558,Xã Kiên Thành,219
+7561,Xã Hồng Giang,219
+7564,Xã Kim Sơn,219
+7567,Xã Tân Hoa,219
+7570,Xã Giáp Sơn,219
+7573,Xã Biển Động,219
+7576,Xã Quý Sơn,219
+7579,Xã Trù Hựu,219
+7582,Xã Phì Điền,219
+7588,Xã Tân Quang,219
+7591,Xã Đồng Cốc,219
+7594,Xã Tân Lập,219
+7597,Xã Phú Nhuận,219
+7600,Xã Mỹ An,219
+7603,Xã Nam Dương,219
+7606,Xã Tân Mộc,219
+7609,Xã Đèo Gia,219
+7612,Xã Phượng Sơn,219
+7615,Thị trấn An Châu,220
+7616,Thị trấn Tây Yên Tử,220
+7621,Xã Vân Sơn,220
+7624,Xã Hữu Sản,220
+7627,Xã Đại Sơn,220
+7630,Xã Phúc Sơn,220
+7636,Xã Giáo Liêm,220
+7642,Xã Cẩm Đàn,220
+7645,Xã An Lạc,220
+7648,Xã Vĩnh An,220
+7651,Xã Yên Định,220
+7654,Xã Lệ Viễn,220
+7660,Xã An Bá,220
+7663,Xã Tuấn Đạo,220
+7666,Xã Dương Hưu,220
+7672,Xã Long Sơn,220
+7678,Xã Thanh Luận,220
+7681,Thị trấn Nham Biền,221
+7682,Thị trấn Tân An,221
+7684,Xã Lão Hộ,221
+7690,Xã Hương Gián,221
+7702,Xã Quỳnh Sơn,221
+7708,Xã Nội Hoàng,221
+7711,Xã Tiền Phong,221
+7714,Xã Xuân Phú,221
+7717,Xã Tân Liễu,221
+7720,Xã Trí Yên,221
+7723,Xã Lãng Sơn,221
+7726,Xã Yên Lư,221
+7729,Xã Tiến Dũng,221
+7735,Xã Đức Giang,221
+7738,Xã Cảnh Thụy,221
+7741,Xã Tư Mại,221
+7747,Xã Đồng Việt,221
+7750,Xã Đồng Phúc,221
+7759,Xã Thượng Lan,222
+7762,Xã Việt Tiến,222
+7765,Xã Nghĩa Trung,222
+7768,Xã Minh Đức,222
+7771,Xã Hương Mai,222
+7774,Xã Tự Lạn,222
+7777,Thị trấn Bích Động,222
+7780,Xã Trung Sơn,222
+7783,Xã Hồng Thái,222
+7786,Xã Tiên Sơn,222
+7789,Xã Tăng Tiến,222
+7792,Xã Quảng Minh,222
+7795,Thị trấn Nếnh,222
+7798,Xã Ninh Sơn,222
+7801,Xã Vân Trung,222
+7804,Xã Vân Hà,222
+7807,Xã Quang Châu,222
+7813,Xã Đồng Tân,223
+7816,Xã Thanh Vân,223
+7819,Xã Hoàng Lương,223
+7822,Xã Hoàng Vân,223
+7825,Xã Hoàng Thanh,223
+7828,Xã Hoàng An,223
+7831,Xã Ngọc Sơn,223
+7834,Xã Thái Sơn,223
+7837,Xã Hòa Sơn,223
+7840,Thị trấn Thắng,223
+7843,Xã Quang Minh,223
+7846,Xã Lương Phong,223
+7849,Xã Hùng Sơn,223
+7852,Xã Đại Thành,223
+7855,Xã Thường Thắng,223
+7858,Xã Hợp Thịnh,223
+7861,Xã Danh Thắng,223
+7864,Xã Mai Trung,223
+7867,Xã Đoan Bái,223
+7870,Thị trấn Bắc Lý,223
+7873,Xã Xuân Cẩm,223
+7876,Xã Hương Lâm,223
+7879,Xã Đông Lỗ,223
+7882,Xã Châu Minh,223
+7885,Xã Mai Đình,223
+7888,Phường Dữu Lâu,227
+7891,Phường Vân Cơ,227
+7894,Phường Nông Trang,227
+7897,Phường Tân Dân,227
+7900,Phường Gia Cẩm,227
+7903,Phường Tiên Cát,227
+7906,Phường Thọ Sơn,227
+7909,Phường Thanh Miếu,227
+7912,Phường Bạch Hạc,227
+7915,Phường Bến Gót,227
+7918,Phường Vân Phú,227
+7921,Xã Phượng Lâu,227
+7924,Xã Thụy Vân,227
+7927,Phường Minh Phương,227
+7930,Xã Trưng Vương,227
+7933,Phường Minh Nông,227
+7936,Xã Sông Lô,227
+8281,Xã Kim Đức,227
+8287,Xã Hùng Lô,227
+8503,Xã Hy Cương,227
+8506,Xã Chu Hóa,227
+8515,Xã Thanh Đình,227
+7942,Phường Hùng Vương,228
+7945,Phường Phong Châu,228
+7948,Phường Âu Cơ,228
+7951,Xã Hà Lộc,228
+7954,Xã Phú Hộ,228
+7957,Xã Văn Lung,228
+7960,Xã Thanh Minh,228
+7963,Xã Hà Thạch,228
+7966,Phường Thanh Vinh,228
+7969,Thị trấn Đoan Hùng,230
+7975,Xã Hùng Xuyên,230
+7981,Xã Bằng Luân,230
+7984,Xã Vân Du,230
+7987,Xã Phú Lâm,230
+7993,Xã Minh Lương,230
+7996,Xã Bằng Doãn,230
+7999,Xã Chí Đám,230
+8005,Xã Phúc Lai,230
+8008,Xã Ngọc Quan,230
+8014,Xã Hợp Nhất,230
+8017,Xã Sóc Đăng,230
+8023,Xã Tây Cốc,230
+8026,Xã Yên Kiện,230
+8029,Xã Hùng Long,230
+8032,Xã Vụ Quang,230
+8035,Xã Vân Đồn,230
+8038,Xã Tiêu Sơn,230
+8041,Xã Minh Tiến,230
+8044,Xã Minh Phú,230
+8047,Xã Chân Mộng,230
+8050,Xã Ca Đình,230
+8053,Thị trấn Hạ Hoà,231
+8056,Xã Đại Phạm,231
+8062,Xã Đan Thượng,231
+8065,Xã Hà Lương,231
+8071,Xã Tứ Hiệp,231
+8080,Xã Hiền Lương,231
+8089,Xã Phương Viên,231
+8092,Xã Gia Điền,231
+8095,Xã Ấm Hạ,231
+8104,Xã Hương Xạ,231
+8110,Xã Xuân Áng,231
+8113,Xã Yên Kỳ,231
+8119,Xã Minh Hạc,231
+8122,Xã Lang Sơn,231
+8125,Xã Bằng Giã,231
+8128,Xã Yên Luật,231
+8131,Xã Vô Tranh,231
+8134,Xã Văn Lang,231
+8140,Xã Minh Côi,231
+8143,Xã Vĩnh Chân,231
+8152,Thị trấn Thanh Ba,232
+8156,Xã Vân Lĩnh,232
+8158,Xã Đông Lĩnh,232
+8161,Xã Đại An,232
+8164,Xã Hanh Cù,232
+8170,Xã Đồng Xuân,232
+8173,Xã Quảng Yên,232
+8179,Xã Ninh Dân,232
+8194,Xã Võ Lao,232
+8197,Xã Khải Xuân,232
+8200,Xã Mạn Lạn,232
+8203,Xã Hoàng Cương,232
+8206,Xã Chí Tiên,232
+8209,Xã Đông Thành,232
+8215,Xã Sơn Cương,232
+8218,Xã Thanh Hà,232
+8221,Xã Đỗ Sơn,232
+8224,Xã Đỗ Xuyên,232
+8227,Xã Lương Lỗ,232
+8230,Thị trấn Phong Châu,233
+8233,Xã Phú Mỹ,233
+8234,Xã Lệ Mỹ,233
+8236,Xã Liên Hoa,233
+8239,Xã Trạm Thản,233
+8242,Xã Trị Quận,233
+8245,Xã Trung Giáp,233
+8248,Xã Tiên Phú,233
+8251,Xã Hạ Giáp,233
+8254,Xã Bảo Thanh,233
+8257,Xã Phú Lộc,233
+8260,Xã Gia Thanh,233
+8263,Xã Tiên Du,233
+8266,Xã Phú Nham,233
+8272,Xã An Đạo,233
+8275,Xã Bình Phú,233
+8278,Xã Phù Ninh,233
+8290,Thị trấn Yên Lập,234
+8293,Xã Mỹ Lung,234
+8296,Xã Mỹ Lương,234
+8299,Xã Lương Sơn,234
+8302,Xã Xuân An,234
+8305,Xã Xuân Viên,234
+8308,Xã Xuân Thủy,234
+8311,Xã Trung Sơn,234
+8314,Xã Hưng Long,234
+8317,Xã Nga Hoàng,234
+8320,Xã Đồng Lạc,234
+8323,Xã Thượng Long,234
+8326,Xã Đồng Thịnh,234
+8329,Xã Phúc Khánh,234
+8332,Xã Minh Hòa,234
+8335,Xã Ngọc Lập,234
+8338,Xã Ngọc Đồng,234
+8341,Thị trấn Cẩm Khê,235
+8344,Xã Tiên Lương,235
+8347,Xã Tuy Lộc,235
+8350,Xã Ngô Xá,235
+8353,Xã Minh Tân,235
+8356,Xã Phượng Vĩ,235
+8362,Xã Thụy Liễu,235
+8374,Xã Tùng Khê,235
+8377,Xã Tam Sơn,235
+8380,Xã Văn Bán,235
+8383,Xã Cấp Dẫn,235
+8389,Xã Xương Thịnh,235
+8392,Xã Phú Khê,235
+8395,Xã Sơn Tình,235
+8398,Xã Yên Tập,235
+8401,Xã Hương Lung,235
+8404,Xã Tạ Xá,235
+8407,Xã Phú Lạc,235
+8413,Xã Chương Xá,235
+8416,Xã Hùng Việt,235
+8419,Xã Văn Khúc,235
+8422,Xã Yên Dưỡng,235
+8428,Xã Điêu Lương,235
+8431,Xã Đồng Lương,235
+8434,Thị trấn Hưng Hoá,236
+8440,Xã Hiền Quan,236
+8443,Xã Bắc Sơn,236
+8446,Xã Thanh Uyên,236
+8461,Xã Lam Sơn,236
+8467,Xã Vạn Xuân,236
+8470,Xã Quang Húc,236
+8473,Xã Hương Nộn,236
+8476,Xã Tề Lễ,236
+8479,Xã Thọ Văn,236
+8482,Xã Dị Nậu,236
+8491,Xã Dân Quyền,236
+8494,Thị trấn Lâm Thao,237
+8497,Xã Tiên Kiên,237
+8498,Thị trấn Hùng Sơn,237
+8500,Xã Xuân Lũng,237
+8509,Xã Xuân Huy,237
+8512,Xã Thạch Sơn,237
+8518,Xã Sơn Vi,237
+8521,Xã Phùng Nguyên,237
+8527,Xã Cao Xá,237
+8533,Xã Vĩnh Lại,237
+8536,Xã Tứ Xã,237
+8539,Xã Bản Nguyên,237
+8542,Thị trấn Thanh Sơn,238
+8563,Xã Sơn Hùng,238
+8572,Xã Địch Quả,238
+8575,Xã Giáp Lai,238
+8581,Xã Thục Luyện,238
+8584,Xã Võ Miếu,238
+8587,Xã Thạch Khoán,238
+8602,Xã Cự Thắng,238
+8605,Xã Tất Thắng,238
+8611,Xã Văn Miếu,238
+8614,Xã Cự Đồng,238
+8623,Xã Thắng Sơn,238
+8629,Xã Tân Minh,238
+8632,Xã Hương Cần,238
+8635,Xã Khả Cửu,238
+8638,Xã Đông Cửu,238
+8641,Xã Tân Lập,238
+8644,Xã Yên Lãng,238
+8647,Xã Yên Lương,238
+8650,Xã Thượng Cửu,238
+8653,Xã Lương Nha,238
+8656,Xã Yên Sơn,238
+8659,Xã Tinh Nhuệ,238
+8662,Xã Đào Xá,239
+8665,Xã Thạch Đồng,239
+8668,Xã Xuân Lộc,239
+8671,Xã Tân Phương,239
+8674,Thị trấn Thanh Thủy,239
+8677,Xã Sơn Thủy,239
+8680,Xã Bảo Yên,239
+8683,Xã Đoan Hạ,239
+8686,Xã Đồng Trung,239
+8689,Xã Hoàng Xá,239
+8701,Xã Tu Vũ,239
+8545,Xã Thu Cúc,240
+8548,Xã Thạch Kiệt,240
+8551,Xã Thu Ngạc,240
+8554,Xã Kiệt Sơn,240
+8557,Xã Đồng Sơn,240
+8560,Xã Lai Đồng,240
+8566,Xã Tân Phú,240
+8569,Xã Mỹ Thuận,240
+8578,Xã Tân Sơn,240
+8590,Xã Xuân Đài,240
+8593,Xã Minh Đài,240
+8596,Xã Văn Luông,240
+8599,Xã Xuân Sơn,240
+8608,Xã Long Cốc,240
+8617,Xã Kim Thượng,240
+8620,Xã Tam Thanh,240
+8626,Xã Vinh Tiền,240
+8707,Phường Tích Sơn,243
+8710,Phường Liên Bảo,243
+8713,Phường Hội Hợp,243
+8716,Phường Đống Đa,243
+8719,Phường Ngô Quyền,243
+8722,Phường Đồng Tâm,243
+8725,Xã Định Trung,243
+8728,Phường Khai Quang,243
+8731,Xã Thanh Trù,243
+8734,Phường Trưng Trắc,244
+8737,Phường Hùng Vương,244
+8740,Phường Trưng Nhị,244
+8743,Phường Phúc Thắng,244
+8746,Phường Xuân Hoà,244
+8747,Phường Đồng Xuân,244
+8749,Xã Ngọc Thanh,244
+8752,Xã Cao Minh,244
+8755,Phường Nam Viêm,244
+8758,Phường Tiền Châu,244
+8761,Thị trấn Lập Thạch,246
+8764,Xã Quang Sơn,246
+8767,Xã Ngọc Mỹ,246
+8770,Xã Hợp Lý,246
+8785,Xã Bắc Bình,246
+8788,Xã Thái Hòa,246
+8789,Thị trấn Hoa Sơn,246
+8791,Xã Liễn Sơn,246
+8794,Xã Xuân Hòa,246
+8797,Xã Vân Trục,246
+8812,Xã Liên Hòa,246
+8815,Xã Tử Du,246
+8833,Xã Bàn Giản,246
+8836,Xã Xuân Lôi,246
+8839,Xã Đồng Ích,246
+8842,Xã Tiên Lữ,246
+8845,Xã Văn Quán,246
+8857,Xã Đình Chu,246
+8863,Xã Triệu Đề,246
+8866,Xã Sơn Đông,246
+8869,Thị trấn Hợp Hòa,247
+8872,Xã Hoàng Hoa,247
+8875,Xã Đồng Tĩnh,247
+8878,Xã Kim Long,247
+8881,Xã Hướng Đạo,247
+8884,Xã Đạo Tú,247
+8887,Xã An Hòa,247
+8890,Xã Thanh Vân,247
+8893,Xã Duy Phiên,247
+8896,Xã Hoàng Đan,247
+8899,Xã Hoàng Lâu,247
+8902,Xã Vân Hội,247
+8905,Xã Hợp Thịnh,247
+8908,Thị trấn Tam Đảo,248
+8911,Thị trấn Hợp Châu,248
+8914,Xã Đạo Trù,248
+8917,Xã Yên Dương,248
+8920,Xã Bồ Lý,248
+8923,Thị trấn Đại Đình,248
+8926,Xã Tam Quan,248
+8929,Xã Hồ Sơn,248
+8932,Xã Minh Quang,248
+8935,Thị trấn Hương Canh,249
+8936,Thị trấn Gia Khánh,249
+8938,Xã Trung Mỹ,249
+8944,Thị trấn Bá Hiến,249
+8947,Xã Thiện Kế,249
+8950,Xã Hương Sơn,249
+8953,Xã Tam Hợp,249
+8956,Xã Quất Lưu,249
+8959,Xã Sơn Lôi,249
+8962,Thị trấn Đạo Đức,249
+8965,Xã Tân Phong,249
+8968,Thị trấn Thanh Lãng,249
+8971,Xã Phú Xuân,249
+9025,Thị trấn Yên Lạc,251
+9028,Xã Đồng Cương,251
+9031,Xã Đồng Văn,251
+9034,Xã Bình Định,251
+9037,Xã Trung Nguyên,251
+9040,Xã Tề Lỗ,251
+9043,Xã Tam Hồng,251
+9046,Xã Yên Đồng,251
+9049,Xã Văn Tiến,251
+9052,Xã Nguyệt Đức,251
+9055,Xã Yên Phương,251
+9058,Xã Hồng Phương,251
+9061,Xã Trung Kiên,251
+9064,Xã Liên Châu,251
+9067,Xã Đại Tự,251
+9070,Xã Hồng Châu,251
+9073,Xã Trung Hà,251
+9076,Thị trấn Vĩnh Tường,252
+9079,Xã Kim Xá,252
+9082,Xã Yên Bình,252
+9085,Xã Chấn Hưng,252
+9088,Xã Nghĩa Hưng,252
+9091,Xã Yên Lập,252
+9094,Xã Việt Xuân,252
+9097,Xã Bồ Sao,252
+9100,Xã Đại Đồng,252
+9103,Xã Tân Tiến,252
+9106,Xã Lũng Hoà,252
+9109,Xã Cao Đại,252
+9112,Thị Trấn Thổ Tang,252
+9115,Xã Vĩnh Sơn,252
+9118,Xã Bình Dương,252
+9124,Xã Tân Phú,252
+9127,Xã Thượng Trưng,252
+9130,Xã Vũ Di,252
+9133,Xã Lý Nhân,252
+9136,Xã Tuân Chính,252
+9139,Xã Vân Xuân,252
+9142,Xã Tam Phúc,252
+9145,Thị trấn Tứ Trưng,252
+9148,Xã Ngũ Kiên,252
+9151,Xã An Tường,252
+9154,Xã Vĩnh Thịnh,252
+9157,Xã Phú Đa,252
+9160,Xã Vĩnh Ninh,252
+8773,Xã Lãng Công,253
+8776,Xã Quang Yên,253
+8779,Xã Bạch Lưu,253
+8782,Xã Hải Lựu,253
+8800,Xã Đồng Quế,253
+8803,Xã Nhân Đạo,253
+8806,Xã Đôn Nhân,253
+8809,Xã Phương Khoan,253
+8818,Xã Tân Lập,253
+8821,Xã Nhạo Sơn,253
+8824,Thị trấn Tam Sơn,253
+8827,Xã Như Thụy,253
+8830,Xã Yên Thạch,253
+8848,Xã Đồng Thịnh,253
+8851,Xã Tứ Yên,253
+8854,Xã Đức Bác,253
+8860,Xã Cao Phong,253
+9163,Phường Vũ Ninh,256
+9166,Phường Đáp Cầu,256
+9169,Phường Thị Cầu,256
+9172,Phường Kinh Bắc,256
+9175,Phường Vệ An,256
+9178,Phường Tiền An,256
+9181,Phường Đại Phúc,256
+9184,Phường Ninh Xá,256
+9187,Phường Suối Hoa,256
+9190,Phường Võ Cường,256
+9214,Phường Hòa Long,256
+9226,Phường Vạn An,256
+9235,Phường Khúc Xuyên,256
+9244,Phường Phong Khê,256
+9256,Phường Kim Chân,256
+9271,Phường Vân Dương,256
+9286,Phường Nam Sơn,256
+9325,Phường Khắc Niệm,256
+9331,Phường Hạp Lĩnh,256
+9193,Thị trấn Chờ,258
+9196,Xã Dũng Liệt,258
+9199,Xã Tam Đa,258
+9202,Xã Tam Giang,258
+9205,Xã Yên Trung,258
+9208,Xã Thụy Hòa,258
+9211,Xã Hòa Tiến,258
+9217,Xã Đông Tiến,258
+9220,Xã Yên Phụ,258
+9223,Xã Trung Nghĩa,258
+9229,Xã Đông Phong,258
+9232,Xã Long Châu,258
+9238,Xã Văn Môn,258
+9241,Xã Đông Thọ,258
+9247,Thị trấn Phố Mới,259
+9250,Xã Việt Thống,259
+9253,Xã Đại Xuân,259
+9259,Xã Nhân Hòa,259
+9262,Xã Bằng An,259
+9265,Xã Phương Liễu,259
+9268,Xã Quế Tân,259
+9274,Xã Phù Lương,259
+9277,Xã Phù Lãng,259
+9280,Xã Phượng Mao,259
+9283,Xã Việt Hùng,259
+9289,Xã Ngọc Xá,259
+9292,Xã Châu Phong,259
+9295,Xã Bồng Lai,259
+9298,Xã Cách Bi,259
+9301,Xã Đào Viên,259
+9304,Xã Yên Giả,259
+9307,Xã Mộ Đạo,259
+9310,Xã Đức Long,259
+9313,Xã Chi Lăng,259
+9316,Xã Hán Quảng,259
+9319,Thị trấn Lim,260
+9322,Xã Phú Lâm,260
+9328,Xã Nội Duệ,260
+9334,Xã Liên Bão,260
+9337,Xã Hiên Vân,260
+9340,Xã Hoàn Sơn,260
+9343,Xã Lạc Vệ,260
+9346,Xã Việt Đoàn,260
+9349,Xã Phật Tích,260
+9352,Xã Tân Chi,260
+9355,Xã Đại Đồng,260
+9358,Xã Tri Phương,260
+9361,Xã Minh Đạo,260
+9364,Xã Cảnh Hưng,260
+9367,Phường Đông Ngàn,261
+9370,Phường Tam Sơn,261
+9373,Phường Hương Mạc,261
+9376,Phường Tương Giang,261
+9379,Phường Phù Khê,261
+9382,Phường Đồng Kỵ,261
+9383,Phường Trang Hạ,261
+9385,Phường Đồng Nguyên,261
+9388,Phường Châu Khê,261
+9391,Phường Tân Hồng,261
+9394,Phường Đình Bảng,261
+9397,Phường Phù Chẩn,261
+9400,Thị trấn Hồ,262
+9403,Xã Hoài Thượng,262
+9406,Xã Đại Đồng Thành,262
+9409,Xã Mão Điền,262
+9412,Xã Song Hồ,262
+9415,Xã Đình Tổ,262
+9418,Xã An Bình,262
+9421,Xã Trí Quả,262
+9424,Xã Gia Đông,262
+9427,Xã Thanh Khương,262
+9430,Xã Trạm Lộ,262
+9433,Xã Xuân Lâm,262
+9436,Xã Hà Mãn,262
+9439,Xã Ngũ Thái,262
+9442,Xã Nguyệt Đức,262
+9445,Xã Ninh Xá,262
+9448,Xã Nghĩa Đạo,262
+9451,Xã Song Liễu,262
+9454,Thị trấn Gia Bình,263
+9457,Xã Vạn Ninh,263
+9460,Xã Thái Bảo,263
+9463,Xã Giang Sơn,263
+9466,Xã Cao Đức,263
+9469,Xã Đại Lai,263
+9472,Xã Song Giang,263
+9475,Xã Bình Dương,263
+9478,Xã Lãng Ngâm,263
+9481,Xã Nhân Thắng,263
+9484,Xã Xuân Lai,263
+9487,Xã Đông Cứu,263
+9490,Xã Đại Bái,263
+9493,Xã Quỳnh Phú,263
+9496,Thị trấn Thứa,264
+9499,Xã An Thịnh,264
+9502,Xã Trung Kênh,264
+9505,Xã Phú Hòa,264
+9508,Xã Mỹ Hương,264
+9511,Xã Tân Lãng,264
+9514,Xã Quảng Phú,264
+9517,Xã Trừng Xá,264
+9520,Xã Lai Hạ,264
+9523,Xã Trung Chính,264
+9526,Xã Minh Tân,264
+9529,Xã Bình Định,264
+9532,Xã Phú Lương,264
+9535,Xã Lâm Thao,264
+10507,Phường Cẩm Thượng,288
+10510,Phường Bình Hàn,288
+10513,Phường Ngọc Châu,288
+10514,Phường Nhị Châu,288
+10516,Phường Quang Trung,288
+10519,Phường Nguyễn Trãi,288
+10522,Phường Phạm Ngũ Lão,288
+10525,Phường Trần Hưng Đạo,288
+10528,Phường Trần Phú,288
+10531,Phường Thanh Bình,288
+10532,Phường Tân Bình,288
+10534,Phường Lê Thanh Nghị,288
+10537,Phường Hải Tân,288
+10540,Phường Tứ Minh,288
+10543,Phường Việt Hoà,288
+10660,Phường Ái Quốc,288
+10663,Xã An Thượng,288
+10672,Phường Nam Đồng,288
+10822,Xã Quyết Thắng,288
+10837,Xã Tiền Tiến,288
+11002,Phường Thạch Khôi,288
+11005,Xã Liên Hồng,288
+11011,Phường Tân Hưng,288
+11017,Xã Gia Xuyên,288
+11077,Xã Ngọc Sơn,288
+10546,Phường Phả Lại,290
+10549,Phường Sao Đỏ,290
+10552,Phường Bến Tắm,290
+10555,Xã Hoàng Hoa Thám,290
+10558,Xã Bắc An,290
+10561,Xã Hưng Đạo,290
+10564,Xã Lê Lợi,290
+10567,Phường Hoàng Tiến,290
+10570,Phường Cộng Hoà,290
+10573,Phường Hoàng Tân,290
+10576,Phường Cổ Thành,290
+10579,Phường Văn An,290
+10582,Phường Chí Minh,290
+10585,Phường Văn Đức,290
+10588,Phường Thái Học,290
+10591,Xã Nhân Huệ,290
+10594,Phường An Lạc,290
+10600,Phường Đồng Lạc,290
+10603,Phường Tân Dân,290
+10606,Thị trấn Nam Sách,291
+10609,Xã Nam Hưng,291
+10612,Xã Nam Tân,291
+10615,Xã Hợp Tiến,291
+10618,Xã Hiệp Cát,291
+10621,Xã Thanh Quang,291
+10624,Xã Quốc Tuấn,291
+10627,Xã Nam Chính,291
+10630,Xã An Bình,291
+10633,Xã Nam Trung,291
+10636,Xã An Sơn,291
+10639,Xã Cộng Hòa,291
+10642,Xã Thái Tân,291
+10645,Xã An Lâm,291
+10648,Xã Phú Điền,291
+10651,Xã Nam Hồng,291
+10654,Xã Hồng Phong,291
+10657,Xã Đồng Lạc,291
+10666,Xã Minh Tân,291
+10675,Phường An Lưu,292
+10678,Xã Bạch Đằng,292
+10681,Phường Thất Hùng,292
+10684,Xã Lê Ninh,292
+10687,Xã Hoành Sơn,292
+10693,Phường Phạm Thái,292
+10696,Phường Duy Tân,292
+10699,Phường Tân Dân,292
+10702,Phường Minh Tân,292
+10705,Xã Quang Thành,292
+10708,Xã Hiệp Hòa,292
+10714,Phường Phú Thứ,292
+10717,Xã Thăng Long,292
+10720,Xã Lạc Long,292
+10723,Phường An Sinh,292
+10726,Phường Hiệp Sơn,292
+10729,Xã Thượng Quận,292
+10732,Phường An Phụ,292
+10735,Phường Hiệp An,292
+10738,Phường Long Xuyên,292
+10741,Phường Thái Thịnh,292
+10744,Phường Hiến Thành,292
+10747,Xã Minh Hòa,292
+10750,Thị trấn Phú Thái,293
+10753,Xã Lai Vu,293
+10756,Xã Cộng Hòa,293
+10759,Xã Thượng Vũ,293
+10762,Xã Cổ Dũng,293
+10768,Xã Tuấn Việt,293
+10771,Xã Kim Xuyên,293
+10774,Xã Phúc Thành A,293
+10777,Xã Ngũ Phúc,293
+10780,Xã Kim Anh,293
+10783,Xã Kim Liên,293
+10786,Xã Kim Tân,293
+10792,Xã Kim Đính,293
+10798,Xã Bình Dân,293
+10801,Xã Tam Kỳ,293
+10804,Xã Đồng Cẩm,293
+10807,Xã Liên Hòa,293
+10810,Xã Đại Đức,293
+10813,Thị trấn Thanh Hà,294
+10816,Xã Hồng Lạc,294
+10819,Xã Việt Hồng,294
+10825,Xã Tân Việt,294
+10828,Xã Cẩm Chế,294
+10831,Xã Thanh An,294
+10834,Xã Thanh Lang,294
+10840,Xã Tân An,294
+10843,Xã Liên Mạc,294
+10846,Xã Thanh Hải,294
+10849,Xã Thanh Khê,294
+10852,Xã Thanh Xá,294
+10855,Xã Thanh Xuân,294
+10861,Xã Thanh Thủy,294
+10864,Xã An Phượng,294
+10867,Xã Thanh Sơn,294
+10876,Xã Thanh Quang,294
+10879,Xã Thanh Hồng,294
+10882,Xã Thanh Cường,294
+10885,Xã Vĩnh Lập,294
+10888,Thị trấn Cẩm Giang,295
+10891,Thị trấn Lai Cách,295
+10894,Xã Cẩm Hưng,295
+10897,Xã Cẩm Hoàng,295
+10900,Xã Cẩm Văn,295
+10903,Xã Ngọc Liên,295
+10906,Xã Thạch Lỗi,295
+10909,Xã Cẩm Vũ,295
+10912,Xã Đức Chính,295
+10918,Xã Định Sơn,295
+10924,Xã Lương Điền,295
+10927,Xã Cao An,295
+10930,Xã Tân Trường,295
+10933,Xã Cẩm Phúc,295
+10936,Xã Cẩm Điền,295
+10939,Xã Cẩm Đông,295
+10942,Xã Cẩm Đoài,295
+10945,Thị trấn Kẻ Sặt,296
+10951,Xã Vĩnh Hưng,296
+10954,Xã Hùng Thắng,296
+10960,Xã Vĩnh Hồng,296
+10963,Xã Long Xuyên,296
+10966,Xã Tân Việt,296
+10969,Xã Thúc Kháng,296
+10972,Xã Tân Hồng,296
+10975,Xã Bình Minh,296
+10978,Xã Hồng Khê,296
+10981,Xã Thái Học,296
+10984,Xã Cổ Bì,296
+10987,Xã Nhân Quyền,296
+10990,Xã Thái Dương,296
+10993,Xã Thái Hòa,296
+10996,Xã Bình Xuyên,296
+10999,Thị trấn Gia Lộc,297
+11008,Xã Thống Nhất,297
+11020,Xã Yết Kiêu,297
+11029,Xã Gia Tân,297
+11032,Xã Tân Tiến,297
+11035,Xã Gia Khánh,297
+11038,Xã Gia Lương,297
+11041,Xã Lê Lợi,297
+11044,Xã Toàn Thắng,297
+11047,Xã Hoàng Diệu,297
+11050,Xã Hồng Hưng,297
+11053,Xã Phạm Trấn,297
+11056,Xã Đoàn Thượng,297
+11059,Xã Thống Kênh,297
+11062,Xã Quang Minh,297
+11065,Xã Đồng Quang,297
+11068,Xã Nhật Tân,297
+11071,Xã Đức Xương,297
+11074,Thị trấn Tứ Kỳ,298
+11083,Xã Đại Sơn,298
+11086,Xã Hưng Đạo,298
+11089,Xã Ngọc Kỳ,298
+11092,Xã Bình Lăng,298
+11095,Xã Chí Minh,298
+11098,Xã Tái Sơn,298
+11101,Xã Quang Phục,298
+11110,Xã Dân Chủ,298
+11113,Xã Tân Kỳ,298
+11116,Xã Quang Khải,298
+11119,Xã Đại Hợp,298
+11122,Xã Quảng Nghiệp,298
+11125,Xã An Thanh,298
+11128,Xã Minh Đức,298
+11131,Xã Văn Tố,298
+11134,Xã Quang Trung,298
+11137,Xã Phượng Kỳ,298
+11140,Xã Cộng Lạc,298
+11143,Xã Tiên Động,298
+11146,Xã Nguyên Giáp,298
+11149,Xã Hà Kỳ,298
+11152,Xã Hà Thanh,298
+11155,Thị trấn Ninh Giang,299
+11161,Xã Ứng Hoè,299
+11164,Xã Nghĩa An,299
+11167,Xã Hồng Đức,299
+11173,Xã An Đức,299
+11176,Xã Vạn Phúc,299
+11179,Xã Tân Hương,299
+11185,Xã Vĩnh Hòa,299
+11188,Xã Đông Xuyên,299
+11197,Xã Tân Phong,299
+11200,Xã Ninh Hải,299
+11203,Xã Đồng Tâm,299
+11206,Xã Tân Quang,299
+11209,Xã Kiến Quốc,299
+11215,Xã Hồng Dụ,299
+11218,Xã Văn Hội,299
+11224,Xã Hồng Phong,299
+11227,Xã Hiệp Lực,299
+11230,Xã Hồng Phúc,299
+11233,Xã Hưng Long,299
+11239,Thị trấn Thanh Miện,300
+11242,Xã Thanh Tùng,300
+11245,Xã Phạm Kha,300
+11248,Xã Ngô Quyền,300
+11251,Xã Đoàn Tùng,300
+11254,Xã Hồng Quang,300
+11257,Xã Tân Trào,300
+11260,Xã Lam Sơn,300
+11263,Xã Đoàn Kết,300
+11266,Xã Lê Hồng,300
+11269,Xã Tứ Cường,300
+11275,Xã Ngũ Hùng,300
+11278,Xã Cao Thắng,300
+11281,Xã Chi Lăng Bắc,300
+11284,Xã Chi Lăng Nam,300
+11287,Xã Thanh Giang,300
+11293,Xã Hồng Phong,300
+11296,Phường Quán Toan,303
+11299,Phường Hùng Vương,303
+11302,Phường Sở Dầu,303
+11305,Phường Thượng Lý,303
+11308,Phường Hạ Lý,303
+11311,Phường Minh Khai,303
+11314,Phường Trại Chuối,303
+11320,Phường Hoàng Văn Thụ,303
+11323,Phường Phan Bội Châu,303
+11329,Phường Máy Chai,304
+11332,Phường Máy Tơ,304
+11335,Phường Vạn Mỹ,304
+11338,Phường Cầu Tre,304
+11341,Phường Lạc Viên,304
+11344,Phường Cầu Đất,304
+11347,Phường Gia Viên,304
+11350,Phường Đông Khê,304
+11356,Phường Lê Lợi,304
+11359,Phường Đằng Giang,304
+11362,Phường Lạch Tray,304
+11365,Phường Đổng Quốc Bình,304
+11368,Phường Cát Dài,305
+11371,Phường An Biên,305
+11374,Phường Lam Sơn,305
+11377,Phường An Dương,305
+11380,Phường Trần Nguyên Hãn,305
+11383,Phường Hồ Nam,305
+11386,Phường Trại Cau,305
+11389,Phường Dư Hàng,305
+11392,Phường Hàng Kênh,305
+11395,Phường Đông Hải,305
+11398,Phường Niệm Nghĩa,305
+11401,Phường Nghĩa Xá,305
+11404,Phường Dư Hàng Kênh,305
+11405,Phường Kênh Dương,305
+11407,Phường Vĩnh Niệm,305
+11410,Phường Đông Hải 1,306
+11411,Phường Đông Hải 2,306
+11413,Phường Đằng Lâm,306
+11414,Phường Thành Tô,306
+11416,Phường Đằng Hải,306
+11419,Phường Nam Hải,306
+11422,Phường Cát Bi,306
+11425,Phường Tràng Cát,306
+11428,Phường Quán Trữ,307
+11429,Phường Lãm Hà,307
+11431,Phường Đồng Hoà,307
+11434,Phường Bắc Sơn,307
+11437,Phường Nam Sơn,307
+11440,Phường Ngọc Sơn,307
+11443,Phường Trần Thành Ngọ,307
+11446,Phường Văn Đẩu,307
+11449,Phường Phù Liễn,307
+11452,Phường Tràng Minh,307
+11455,Phường Ngọc Xuyên,308
+11458,Phường Hải Sơn,308
+11461,Phường Vạn Hương,308
+11465,Phường Minh Đức,308
+11467,Phường Bàng La,308
+11737,Phường Hợp Đức,308
+11683,Phường Đa Phúc,309
+11686,Phường Hưng Đạo,309
+11689,Phường Anh Dũng,309
+11692,Phường Hải Thành,309
+11707,Phường Hoà Nghĩa,309
+11740,Phường Tân Thành,309
+11470,Thị trấn Núi Đèo,311
+11473,Thị trấn Minh Đức,311
+11476,Xã Lại Xuân,311
+11479,Xã An Sơn,311
+11482,Xã Kỳ Sơn,311
+11485,Xã Liên Khê,311
+11488,Xã Lưu Kiếm,311
+11491,Xã Lưu Kỳ,311
+11494,Xã Gia Minh,311
+11497,Xã Gia Đức,311
+11500,Xã Minh Tân,311
+11503,Xã Phù Ninh,311
+11506,Xã Quảng Thanh,311
+11509,Xã Chính Mỹ,311
+11512,Xã Kênh Giang,311
+11515,Xã Hợp Thành,311
+11518,Xã Cao Nhân,311
+11521,Xã Mỹ Đồng,311
+11524,Xã Đông Sơn,311
+11527,Xã Hoà Bình,311
+11530,Xã Trung Hà,311
+11533,Xã An Lư,311
+11536,Xã Thuỷ Triều,311
+11539,Xã Ngũ Lão,311
+11542,Xã Phục Lễ,311
+11545,Xã Tam Hưng,311
+11548,Xã Phả Lễ,311
+11551,Xã Lập Lễ,311
+11554,Xã Kiền Bái,311
+11557,Xã Thiên Hương,311
+11560,Xã Thuỷ Sơn,311
+11563,Xã Thuỷ Đường,311
+11566,Xã Hoàng Động,311
+11569,Xã Lâm Động,311
+11572,Xã Hoa Động,311
+11575,Xã Tân Dương,311
+11578,Xã Dương Quan,311
+11581,Thị trấn An Dương,312
+11584,Xã Lê Thiện,312
+11587,Xã Đại Bản,312
+11590,Xã An Hoà,312
+11593,Xã Hồng Phong,312
+11596,Xã Tân Tiến,312
+11599,Xã An Hưng,312
+11602,Xã An Hồng,312
+11605,Xã Bắc Sơn,312
+11608,Xã Nam Sơn,312
+11611,Xã Lê Lợi,312
+11614,Xã Đặng Cương,312
+11617,Xã Đồng Thái,312
+11620,Xã Quốc Tuấn,312
+11623,Xã An Đồng,312
+11626,Xã Hồng Thái,312
+11629,Thị trấn An Lão,313
+11632,Xã Bát Trang,313
+11635,Xã Trường Thọ,313
+11638,Xã Trường Thành,313
+11641,Xã An Tiến,313
+11644,Xã Quang Hưng,313
+11647,Xã Quang Trung,313
+11650,Xã Quốc Tuấn,313
+11653,Xã An Thắng,313
+11656,Thị trấn Trường Sơn,313
+11659,Xã Tân Dân,313
+11662,Xã Thái Sơn,313
+11665,Xã Tân Viên,313
+11668,Xã Mỹ Đức,313
+11671,Xã Chiến Thắng,313
+11674,Xã An Thọ,313
+11677,Xã An Thái,313
+11680,Thị trấn Núi Đối,314
+11695,Xã Đông Phương,314
+11698,Xã Thuận Thiên,314
+11701,Xã Hữu Bằng,314
+11704,Xã Đại Đồng,314
+11710,Xã Ngũ Phúc,314
+11713,Xã Kiến Quốc,314
+11716,Xã Du Lễ,314
+11719,Xã Thuỵ Hương,314
+11722,Xã Thanh Sơn,314
+11725,Xã Minh Tân,314
+11728,Xã Đại Hà,314
+11731,Xã Ngũ Đoan,314
+11734,Xã Tân Phong,314
+11743,Xã Tân Trào,314
+11746,Xã Đoàn Xá,314
+11749,Xã Tú Sơn,314
+11752,Xã Đại Hợp,314
+11755,Thị trấn Tiên Lãng,315
+11758,Xã Đại Thắng,315
+11761,Xã Tiên Cường,315
+11764,Xã Tự Cường,315
+11770,Xã Quyết Tiến,315
+11773,Xã Khởi Nghĩa,315
+11776,Xã Tiên Thanh,315
+11779,Xã Cấp Tiến,315
+11782,Xã Kiến Thiết,315
+11785,Xã Đoàn Lập,315
+11788,Xã Bạch Đằng,315
+11791,Xã Quang Phục,315
+11794,Xã Toàn Thắng,315
+11797,Xã Tiên Thắng,315
+11800,Xã Tiên Minh,315
+11803,Xã Bắc Hưng,315
+11806,Xã Nam Hưng,315
+11809,Xã Hùng Thắng,315
+11812,Xã Tây Hưng,315
+11815,Xã Đông Hưng,315
+11821,Xã Vinh Quang,315
+11824,Thị trấn Vĩnh Bảo,316
+11827,Xã Dũng Tiến,316
+11830,Xã Giang Biên,316
+11833,Xã Thắng Thuỷ,316
+11836,Xã Trung Lập,316
+11839,Xã Việt Tiến,316
+11842,Xã Vĩnh An,316
+11845,Xã Vĩnh Long,316
+11848,Xã Hiệp Hoà,316
+11851,Xã Hùng Tiến,316
+11854,Xã An Hoà,316
+11857,Xã Tân Hưng,316
+11860,Xã Tân Liên,316
+11863,Xã Nhân Hoà,316
+11866,Xã Tam Đa,316
+11869,Xã Hưng Nhân,316
+11872,Xã Vinh Quang,316
+11875,Xã Đồng Minh,316
+11878,Xã Thanh Lương,316
+11881,Xã Liên Am,316
+11884,Xã Lý Học,316
+11887,Xã Tam Cường,316
+11890,Xã Hoà Bình,316
+11893,Xã Tiền Phong,316
+11896,Xã Vĩnh Phong,316
+11899,Xã Cộng Hiền,316
+11902,Xã Cao Minh,316
+11905,Xã Cổ Am,316
+11908,Xã Vĩnh Tiến,316
+11911,Xã Trấn Dương,316
+11914,Thị trấn Cát Bà,317
+11917,Thị trấn Cát Hải,317
+11920,Xã Nghĩa Lộ,317
+11923,Xã Đồng Bài,317
+11926,Xã Hoàng Châu,317
+11929,Xã Văn Phong,317
+11932,Xã Phù Long,317
+11935,Xã Gia Luận,317
+11938,Xã Hiền Hào,317
+11941,Xã Trân Châu,317
+11944,Xã Việt Hải,317
+11947,Xã Xuân Đám,317
+11950,Phường Lam Sơn,323
+11953,Phường Hiến Nam,323
+11956,Phường An Tảo,323
+11959,Phường Lê Lợi,323
+11962,Phường Minh Khai,323
+11965,Phường Quang Trung,323
+11968,Phường Hồng Châu,323
+11971,Xã Trung Nghĩa,323
+11974,Xã Liên Phương,323
+11977,Xã Hồng Nam,323
+11980,Xã Quảng Châu,323
+11983,Xã Bảo Khê,323
+12331,Xã Phú Cường,323
+12334,Xã Hùng Cường,323
+12382,Xã Phương Chiểu,323
+12385,Xã Tân Hưng,323
+12388,Xã Hoàng Hanh,323
+11986,Thị trấn Như Quỳnh,325
+11989,Xã Lạc Đạo,325
+11992,Xã Chỉ Đạo,325
+11995,Xã Đại Đồng,325
+11998,Xã Việt Hưng,325
+12001,Xã Tân Quang,325
+12004,Xã Đình Dù,325
+12007,Xã Minh Hải,325
+12010,Xã Lương Tài,325
+12013,Xã Trưng Trắc,325
+12016,Xã Lạc Hồng,325
+12019,Thị trấn Văn Giang,326
+12022,Xã Xuân Quan,326
+12025,Xã Cửu Cao,326
+12028,Xã Phụng Công,326
+12031,Xã Nghĩa Trụ,326
+12034,Xã Long Hưng,326
+12037,Xã Vĩnh Khúc,326
+12040,Xã Liên Nghĩa,326
+12043,Xã Tân Tiến,326
+12046,Xã Thắng Lợi,326
+12049,Xã Mễ Sở,326
+12052,Thị trấn Yên Mỹ,327
+12055,Xã Giai Phạm,327
+12058,Xã Nghĩa Hiệp,327
+12061,Xã Đồng Than,327
+12064,Xã Ngọc Long,327
+12067,Xã Liêu Xá,327
+12070,Xã Hoàn Long,327
+12073,Xã Tân Lập,327
+12076,Xã Thanh Long,327
+12079,Xã Yên Phú,327
+12082,Xã Việt Cường,327
+12085,Xã Trung Hòa,327
+12088,Xã Yên Hòa,327
+12091,Xã Minh Châu,327
+12094,Xã Trung Hưng,327
+12097,Xã Lý Thường Kiệt,327
+12100,Xã Tân Việt,327
+12103,Phường Bần Yên Nhân,328
+12106,Phường Phan Đình Phùng,328
+12109,Xã Cẩm Xá,328
+12112,Xã Dương Quang,328
+12115,Xã Hòa Phong,328
+12118,Phường Nhân Hòa,328
+12121,Phường Dị Sử,328
+12124,Phường Bạch Sam,328
+12127,Phường Minh Đức,328
+12130,Phường Phùng Chí Kiên,328
+12133,Xã Xuân Dục,328
+12136,Xã Ngọc Lâm,328
+12139,Xã Hưng Long,328
+12142,Thị trấn Ân Thi,329
+12145,Xã Phù Ủng,329
+12148,Xã Bắc Sơn,329
+12151,Xã Bãi Sậy,329
+12154,Xã Đào Dương,329
+12157,Xã Tân Phúc,329
+12160,Xã Vân Du,329
+12163,Xã Quang Vinh,329
+12166,Xã Xuân Trúc,329
+12169,Xã Hoàng Hoa Thám,329
+12172,Xã Quảng Lãng,329
+12175,Xã Văn Nhuệ,329
+12178,Xã Đặng Lễ,329
+12181,Xã Cẩm Ninh,329
+12184,Xã Nguyễn Trãi,329
+12187,Xã Đa Lộc,329
+12190,Xã Hồ Tùng Mậu,329
+12193,Xã Tiền Phong,329
+12196,Xã Hồng Vân,329
+12199,Xã Hồng Quang,329
+12202,Xã Hạ Lễ,329
+12205,Thị trấn Khoái Châu,330
+12208,Xã Đông Tảo,330
+12211,Xã Bình Minh,330
+12214,Xã Dạ Trạch,330
+12217,Xã Hàm Tử,330
+12220,Xã Ông Đình,330
+12223,Xã Tân Dân,330
+12226,Xã Tứ Dân,330
+12229,Xã An Vĩ,330
+12232,Xã Đông Kết,330
+12235,Xã Bình Kiều,330
+12238,Xã Dân Tiến,330
+12241,Xã Đồng Tiến,330
+12244,Xã Hồng Tiến,330
+12247,Xã Tân Châu,330
+12250,Xã Liên Khê,330
+12253,Xã Phùng Hưng,330
+12256,Xã Việt Hòa,330
+12259,Xã Đông Ninh,330
+12262,Xã Đại Tập,330
+12265,Xã Chí Tân,330
+12268,Xã Đại Hưng,330
+12271,Xã Thuần Hưng,330
+12274,Xã Thành Công,330
+12277,Xã Nhuế Dương,330
+12280,Thị trấn Lương Bằng,331
+12283,Xã Nghĩa Dân,331
+12286,Xã Toàn Thắng,331
+12289,Xã Vĩnh Xá,331
+12292,Xã Phạm Ngũ Lão,331
+12295,Xã Thọ Vinh,331
+12298,Xã Đồng Thanh,331
+12301,Xã Song Mai,331
+12304,Xã Chính Nghĩa,331
+12307,Xã Nhân La,331
+12310,Xã Phú Thịnh,331
+12313,Xã Mai Động,331
+12316,Xã Đức Hợp,331
+12319,Xã Hùng An,331
+12322,Xã Ngọc Thanh,331
+12325,Xã Vũ Xá,331
+12328,Xã Hiệp Cường,331
+12337,Thị trấn Vương,332
+12340,Xã Hưng Đạo,332
+12343,Xã Ngô Quyền,332
+12346,Xã Nhật Tân,332
+12349,Xã Dị Chế,332
+12352,Xã Lệ Xá,332
+12355,Xã An Viên,332
+12358,Xã Đức Thắng,332
+12361,Xã Trung Dũng,332
+12364,Xã Hải Triều,332
+12367,Xã Thủ Sỹ,332
+12370,Xã Thiện Phiến,332
+12373,Xã Thụy Lôi,332
+12376,Xã Cương Chính,332
+12379,Xã Minh Phượng,332
+12391,Thị trấn Trần Cao,333
+12394,Xã Minh Tân,333
+12397,Xã Phan Sào Nam,333
+12400,Xã Quang Hưng,333
+12403,Xã Minh Hoàng,333
+12406,Xã Đoàn Đào,333
+12409,Xã Tống Phan,333
+12412,Xã Đình Cao,333
+12415,Xã Nhật Quang,333
+12418,Xã Tiền Tiến,333
+12421,Xã Tam Đa,333
+12424,Xã Minh Tiến,333
+12427,Xã Nguyên Hòa,333
+12430,Xã Tống Trân,333
+12433,Phường Lê Hồng Phong,336
+12436,Phường Bồ Xuyên,336
+12439,Phường Đề Thám,336
+12442,Phường Kỳ Bá,336
+12445,Phường Quang Trung,336
+12448,Phường Phú Khánh,336
+12451,Phường Tiền Phong,336
+12452,Phường Trần Hưng Đạo,336
+12454,Phường Trần Lãm,336
+12457,Xã Đông Hòa,336
+12460,Phường Hoàng Diệu,336
+12463,Xã Phú Xuân,336
+12466,Xã Vũ Phúc,336
+12469,Xã Vũ Chính,336
+12817,Xã Đông Mỹ,336
+12820,Xã Đông Thọ,336
+13084,Xã Vũ Đông,336
+13108,Xã Vũ Lạc,336
+13225,Xã Tân Bình,336
+12472,Thị trấn Quỳnh Côi,338
+12475,Xã An Khê,338
+12478,Xã An Đồng,338
+12481,Xã Quỳnh Hoa,338
+12484,Xã Quỳnh Lâm,338
+12487,Xã Quỳnh Thọ,338
+12490,Xã An Hiệp,338
+12493,Xã Quỳnh Hoàng,338
+12496,Xã Quỳnh Giao,338
+12499,Xã An Thái,338
+12502,Xã An Cầu,338
+12505,Xã Quỳnh Hồng,338
+12508,Xã Quỳnh Khê,338
+12511,Xã Quỳnh Minh,338
+12514,Xã An Ninh,338
+12517,Xã Quỳnh Ngọc,338
+12520,Xã Quỳnh Hải,338
+12523,Thị trấn An Bài,338
+12526,Xã An Ấp,338
+12529,Xã Quỳnh Hội,338
+12532,Xã Châu Sơn,338
+12535,Xã Quỳnh Mỹ,338
+12538,Xã An Quí,338
+12541,Xã An Thanh,338
+12547,Xã An Vũ,338
+12550,Xã An Lễ,338
+12553,Xã Quỳnh Hưng,338
+12556,Xã Quỳnh Bảo,338
+12559,Xã An Mỹ,338
+12562,Xã Quỳnh Nguyên,338
+12565,Xã An Vinh,338
+12568,Xã Quỳnh Xá,338
+12571,Xã An Dục,338
+12574,Xã Đông Hải,338
+12577,Xã Quỳnh Trang,338
+12580,Xã An Tràng,338
+12583,Xã Đồng Tiến,338
+12586,Thị trấn Hưng Hà,339
+12589,Xã Điệp Nông,339
+12592,Xã Tân Lễ,339
+12595,Xã Cộng Hòa,339
+12598,Xã Dân Chủ,339
+12601,Xã Canh Tân,339
+12604,Xã Hòa Tiến,339
+12607,Xã Hùng Dũng,339
+12610,Xã Tân Tiến,339
+12613,Thị trấn Hưng Nhân,339
+12616,Xã Đoan Hùng,339
+12619,Xã Duyên Hải,339
+12622,Xã Tân Hòa,339
+12625,Xã Văn Cẩm,339
+12628,Xã Bắc Sơn,339
+12631,Xã Đông Đô,339
+12634,Xã Phúc Khánh,339
+12637,Xã Liên Hiệp,339
+12640,Xã Tây Đô,339
+12643,Xã Thống Nhất,339
+12646,Xã Tiến Đức,339
+12649,Xã Thái Hưng,339
+12652,Xã Thái Phương,339
+12655,Xã Hòa Bình,339
+12656,Xã Chi Lăng,339
+12658,Xã Minh Khai,339
+12661,Xã Hồng An,339
+12664,Xã Kim Chung,339
+12667,Xã Hồng Lĩnh,339
+12670,Xã Minh Tân,339
+12673,Xã Văn Lang,339
+12676,Xã Độc Lập,339
+12679,Xã Chí Hòa,339
+12682,Xã Minh Hòa,339
+12685,Xã Hồng Minh,339
+12688,Thị trấn Đông Hưng,340
+12691,Xã Đô Lương,340
+12694,Xã Đông Phương,340
+12697,Xã Liên Giang,340
+12700,Xã An Châu,340
+12703,Xã Đông Sơn,340
+12706,Xã Đông Cường,340
+12709,Xã Phú Lương,340
+12712,Xã Mê Linh,340
+12715,Xã Lô Giang,340
+12718,Xã Đông La,340
+12721,Xã Minh Tân,340
+12724,Xã Đông Xá,340
+12727,Xã Chương Dương,340
+12730,Xã Nguyên Xá,340
+12733,Xã Phong Châu,340
+12736,Xã Hợp Tiến,340
+12739,Xã Hồng Việt,340
+12745,Xã Hà Giang,340
+12748,Xã Đông Kinh,340
+12751,Xã Đông Hợp,340
+12754,Xã Thăng Long,340
+12757,Xã Đông Các,340
+12760,Xã Phú Châu,340
+12763,Xã Liên Hoa,340
+12769,Xã Đông Tân,340
+12772,Xã Đông Vinh,340
+12775,Xã Đông Động,340
+12778,Xã Hồng Bạch,340
+12784,Xã Trọng Quan,340
+12790,Xã Hồng Giang,340
+12793,Xã Đông Quan,340
+12796,Xã Đông Quang,340
+12799,Xã Đông Xuân,340
+12802,Xã Đông Á,340
+12808,Xã Đông Hoàng,340
+12811,Xã Đông Dương,340
+12823,Xã Minh Phú,340
+12826,Thị trấn Diêm Điền,341
+12832,Xã Thụy Trường,341
+12841,Xã Hồng Dũng,341
+12844,Xã Thụy Quỳnh,341
+12847,Xã An Tân,341
+12850,Xã Thụy Ninh,341
+12853,Xã Thụy Hưng,341
+12856,Xã Thụy Việt,341
+12859,Xã Thụy Văn,341
+12862,Xã Thụy Xuân,341
+12865,Xã Dương Phúc,341
+12868,Xã Thụy Trình,341
+12871,Xã Thụy Bình,341
+12874,Xã Thụy Chính,341
+12877,Xã Thụy Dân,341
+12880,Xã Thụy Hải,341
+12889,Xã Thụy Liên,341
+12892,Xã Thụy Duyên,341
+12898,Xã Thụy Thanh,341
+12901,Xã Thụy Sơn,341
+12904,Xã Thụy Phong,341
+12907,Xã Thái Thượng,341
+12910,Xã Thái Nguyên,341
+12916,Xã Dương Hồng  Thủy,341
+12919,Xã Thái Giang,341
+12922,Xã Hòa An,341
+12925,Xã Sơn Hà,341
+12934,Xã Thái Phúc,341
+12937,Xã Thái Hưng,341
+12940,Xã Thái Đô,341
+12943,Xã Thái Xuyên,341
+12949,Xã  Mỹ Lộc,341
+12958,Xã Tân Học,341
+12961,Xã Thái Thịnh,341
+12964,Xã Thuần Thành,341
+12967,Xã Thái Thọ,341
+12970,Thị trấn Tiền Hải,342
+12976,Xã Đông Trà,342
+12979,Xã Đông Long,342
+12982,Xã Đông Quí,342
+12985,Xã Vũ Lăng,342
+12988,Xã Đông Xuyên,342
+12991,Xã Tây Lương,342
+12994,Xã Tây Ninh,342
+12997,Xã Đông Trung,342
+13000,Xã Đông Hoàng,342
+13003,Xã Đông Minh,342
+13009,Xã Đông Phong,342
+13012,Xã An Ninh,342
+13018,Xã Đông Cơ,342
+13021,Xã Tây Giang,342
+13024,Xã Đông Lâm,342
+13027,Xã Phương Công,342
+13030,Xã Tây Phong,342
+13033,Xã Tây Tiến,342
+13036,Xã Nam Cường,342
+13039,Xã Vân Trường,342
+13042,Xã Nam Thắng,342
+13045,Xã Nam Chính,342
+13048,Xã Bắc Hải,342
+13051,Xã Nam Thịnh,342
+13054,Xã Nam Hà,342
+13057,Xã Nam Thanh,342
+13060,Xã Nam Trung,342
+13063,Xã Nam Hồng,342
+13066,Xã Nam Hưng,342
+13069,Xã Nam Hải,342
+13072,Xã Nam Phú,342
+13075,Thị trấn Kiến Xương,343
+13078,Xã Trà Giang,343
+13081,Xã Quốc Tuấn,343
+13087,Xã An Bình,343
+13090,Xã Tây Sơn,343
+13093,Xã Hồng Thái,343
+13096,Xã Bình Nguyên,343
+13102,Xã Lê Lợi,343
+13111,Xã Vũ Lễ,343
+13114,Xã Thanh Tân,343
+13117,Xã Thượng Hiền,343
+13120,Xã Nam Cao,343
+13123,Xã Đình Phùng,343
+13126,Xã Vũ Ninh,343
+13129,Xã Vũ An,343
+13132,Xã Quang Lịch,343
+13135,Xã Hòa Bình,343
+13138,Xã Bình Minh,343
+13141,Xã Vũ Quí,343
+13144,Xã Quang Bình,343
+13150,Xã Vũ Trung,343
+13153,Xã Vũ Thắng,343
+13156,Xã Vũ Công,343
+13159,Xã Vũ Hòa,343
+13162,Xã Quang Minh,343
+13165,Xã Quang Trung,343
+13171,Xã Minh Quang,343
+13174,Xã Vũ Bình,343
+13177,Xã Minh Tân,343
+13180,Xã Nam Bình,343
+13183,Xã Bình Thanh,343
+13186,Xã Bình Định,343
+13189,Xã Hồng Tiến,343
+13192,Thị trấn Vũ Thư,344
+13195,Xã Hồng Lý,344
+13198,Xã Đồng Thanh,344
+13201,Xã Xuân Hòa,344
+13204,Xã Hiệp Hòa,344
+13207,Xã Phúc Thành,344
+13210,Xã Tân Phong,344
+13213,Xã Song Lãng,344
+13216,Xã Tân Hòa,344
+13219,Xã Việt Hùng,344
+13222,Xã Minh Lãng,344
+13228,Xã Minh Khai,344
+13231,Xã Dũng Nghĩa,344
+13234,Xã Minh Quang,344
+13237,Xã Tam Quang,344
+13240,Xã Tân Lập,344
+13243,Xã Bách Thuận,344
+13246,Xã Tự Tân,344
+13249,Xã Song An,344
+13252,Xã Trung An,344
+13255,Xã Vũ Hội,344
+13258,Xã Hòa Bình,344
+13261,Xã Nguyên Xá,344
+13264,Xã Việt Thuận,344
+13267,Xã Vũ Vinh,344
+13270,Xã Vũ Đoài,344
+13273,Xã Vũ Tiến,344
+13276,Xã Vũ Vân,344
+13279,Xã Duy Nhất,344
+13282,Xã Hồng Phong,344
+13285,Phường Quang Trung,347
+13288,Phường Lương Khánh Thiện,347
+13291,Phường Lê Hồng Phong,347
+13294,Phường Minh Khai,347
+13297,Phường Hai Bà Trưng,347
+13300,Phường Trần Hưng Đạo,347
+13303,Phường Lam Hạ,347
+13306,Xã Phù Vân,347
+13309,Phường Liêm Chính,347
+13312,Xã Liêm Chung,347
+13315,Phường Thanh Châu,347
+13318,Phường Châu Sơn,347
+13366,Xã Tiên Tân,347
+13372,Xã Tiên Hiệp,347
+13381,Xã Tiên Hải,347
+13426,Xã Kim Bình,347
+13444,Xã Liêm Tuyền,347
+13447,Xã Liêm Tiết,347
+13459,Phường Thanh Tuyền,347
+13507,Xã Đinh Xá,347
+13513,Xã Trịnh Xá,347
+13321,Phường Đồng Văn,349
+13324,Phường Hòa Mạc,349
+13327,Xã Mộc Bắc,349
+13330,Phường Châu Giang,349
+13333,Phường Bạch Thượng,349
+13336,Phường Duy Minh,349
+13339,Xã Mộc Nam,349
+13342,Phường Duy Hải,349
+13345,Xã Chuyên Ngoại,349
+13348,Phường Yên Bắc,349
+13351,Xã Trác Văn,349
+13354,Phường Tiên Nội,349
+13357,Phường Hoàng Đông,349
+13360,Xã Yên Nam,349
+13363,Xã Tiên Ngoại,349
+13369,Xã Tiên Sơn,349
+13384,Thị trấn Quế,350
+13387,Xã Nguyễn Úy,350
+13390,Xã Đại Cương,350
+13393,Xã Lê Hồ,350
+13396,Xã Tượng Lĩnh,350
+13399,Xã Nhật Tựu,350
+13402,Xã Nhật Tân,350
+13405,Xã Đồng Hóa,350
+13408,Xã Hoàng Tây,350
+13411,Xã Tân Sơn,350
+13414,Xã Thụy Lôi,350
+13417,Xã Văn Xá,350
+13420,Xã Khả Phong,350
+13423,Xã Ngọc Sơn,350
+13429,Thị trấn Ba Sao,350
+13432,Xã Liên Sơn,350
+13435,Xã Thi Sơn,350
+13438,Xã Thanh Sơn,350
+13441,Thị trấn Kiện Khê,351
+13450,Xã Liêm Phong,351
+13453,Xã Thanh Hà,351
+13456,Xã Liêm Cần,351
+13465,Xã Liêm Thuận,351
+13468,Xã Thanh Thủy,351
+13471,Xã Thanh Phong,351
+13474,Thị trấn Tân Thanh,351
+13477,Xã Thanh Tân,351
+13480,Xã Liêm Túc,351
+13483,Xã Liêm Sơn,351
+13486,Xã Thanh Hương,351
+13489,Xã Thanh Nghị,351
+13492,Xã Thanh Tâm,351
+13495,Xã Thanh Nguyên,351
+13498,Xã Thanh Hải,351
+13501,Thị trấn Bình Mỹ,352
+13504,Xã Bình Nghĩa,352
+13510,Xã Tràng An,352
+13516,Xã Đồng Du,352
+13519,Xã Ngọc Lũ,352
+13522,Xã Hưng Công,352
+13525,Xã Đồn Xá,352
+13528,Xã An Ninh,352
+13531,Xã Bồ Đề,352
+13534,Xã Bối Cầu,352
+13540,Xã An Nội,352
+13543,Xã Vũ Bản,352
+13546,Xã Trung Lương,352
+13552,Xã An Đổ,352
+13555,Xã La Sơn,352
+13558,Xã Tiêu Động,352
+13561,Xã An Lão,352
+13567,Xã Hợp Lý,353
+13570,Xã Nguyên Lý,353
+13573,Xã Chính Lý,353
+13576,Xã Chân Lý,353
+13579,Xã Đạo Lý,353
+13582,Xã Công Lý,353
+13585,Xã Văn Lý,353
+13588,Xã Bắc Lý,353
+13591,Xã Đức Lý,353
+13594,Xã Trần Hưng Đạo,353
+13597,Thị trấn Vĩnh Trụ,353
+13600,Xã Nhân Thịnh,353
+13606,Xã Nhân Khang,353
+13609,Xã Nhân Mỹ,353
+13612,Xã Nhân Nghĩa,353
+13615,Xã Nhân Chính,353
+13618,Xã Nhân Bình,353
+13621,Xã Phú Phúc,353
+13624,Xã Xuân Khê,353
+13627,Xã Tiến Thắng,353
+13630,Xã Hòa Hậu,353
+13633,Phường Hạ Long,356
+13636,Phường Trần Tế Xương,356
+13639,Phường Vị Hoàng,356
+13642,Phường Vị Xuyên,356
+13645,Phường Quang Trung,356
+13648,Phường Cửa Bắc,356
+13651,Phường Nguyễn Du,356
+13654,Phường Bà Triệu,356
+13657,Phường Trường Thi,356
+13660,Phường Phan Đình Phùng,356
+13663,Phường Ngô Quyền,356
+13666,Phường Trần Hưng Đạo,356
+13669,Phường Trần Đăng Ninh,356
+13672,Phường Năng Tĩnh,356
+13675,Phường Văn Miếu,356
+13678,Phường Trần Quang Khải,356
+13681,Phường Thống Nhất,356
+13684,Phường Lộc Hạ,356
+13687,Phường Lộc Vượng,356
+13690,Phường Cửa Nam,356
+13693,Phường Lộc Hòa,356
+13696,Xã Nam Phong,356
+13699,Phường Mỹ Xá,356
+13702,Xã Lộc An,356
+13705,Xã Nam Vân,356
+13708,Thị trấn Mỹ Lộc,358
+13711,Xã Mỹ Hà,358
+13714,Xã Mỹ Tiến,358
+13717,Xã Mỹ Thắng,358
+13720,Xã Mỹ Trung,358
+13723,Xã Mỹ Tân,358
+13726,Xã Mỹ Phúc,358
+13729,Xã Mỹ Hưng,358
+13732,Xã Mỹ Thuận,358
+13735,Xã Mỹ Thịnh,358
+13738,Xã Mỹ Thành,358
+13741,Thị trấn Gôi,359
+13744,Xã Minh Thuận,359
+13747,Xã Hiển Khánh,359
+13750,Xã Tân Khánh,359
+13753,Xã Hợp Hưng,359
+13756,Xã Đại An,359
+13759,Xã Tân Thành,359
+13762,Xã Cộng Hòa,359
+13765,Xã Trung Thành,359
+13768,Xã Quang Trung,359
+13771,Xã Minh Tân,359
+13774,Xã Liên Bảo,359
+13777,Xã Thành Lợi,359
+13780,Xã Kim Thái,359
+13783,Xã Liên Minh,359
+13786,Xã Đại Thắng,359
+13789,Xã Tam Thanh,359
+13792,Xã Vĩnh Hào,359
+13795,Thị trấn Lâm,360
+13798,Xã Yên Trung,360
+13801,Xã Yên Thành,360
+13804,Xã Yên Tân,360
+13807,Xã Yên Lợi,360
+13810,Xã Yên Thọ,360
+13813,Xã Yên Nghĩa,360
+13816,Xã Yên Minh,360
+13819,Xã Yên Phương,360
+13822,Xã Yên Chính,360
+13825,Xã Yên Bình,360
+13828,Xã Yên Phú,360
+13831,Xã Yên Mỹ,360
+13834,Xã Yên Dương,360
+13840,Xã Yên Hưng,360
+13843,Xã Yên Khánh,360
+13846,Xã Yên Phong,360
+13849,Xã Yên Ninh,360
+13852,Xã Yên Lương,360
+13855,Xã Yên Hồng,360
+13858,Xã Yên Quang,360
+13861,Xã Yên Tiến,360
+13864,Xã Yên Thắng,360
+13867,Xã Yên Phúc,360
+13870,Xã Yên Cường,360
+13873,Xã Yên Lộc,360
+13876,Xã Yên Bằng,360
+13879,Xã Yên Đồng,360
+13882,Xã Yên Khang,360
+13885,Xã Yên Nhân,360
+13888,Xã Yên Trị,360
+13891,Thị trấn Liễu Đề,361
+13894,Thị trấn Rạng Đông,361
+13897,Xã Nghĩa Đồng,361
+13900,Xã Nghĩa Thịnh,361
+13903,Xã Nghĩa Minh,361
+13906,Xã Nghĩa Thái,361
+13909,Xã Hoàng Nam,361
+13912,Xã Nghĩa Châu,361
+13915,Xã Nghĩa Trung,361
+13918,Xã Nghĩa Sơn,361
+13921,Xã Nghĩa Lạc,361
+13924,Xã Nghĩa Hồng,361
+13927,Xã Nghĩa Phong,361
+13930,Xã Nghĩa Phú,361
+13933,Xã Nghĩa Bình,361
+13936,Thị trấn Quỹ Nhất,361
+13939,Xã Nghĩa Tân,361
+13942,Xã Nghĩa Hùng,361
+13945,Xã Nghĩa Lâm,361
+13948,Xã Nghĩa Thành,361
+13951,Xã Phúc Thắng,361
+13954,Xã Nghĩa Lợi,361
+13957,Xã Nghĩa Hải,361
+13963,Xã Nam Điền,361
+13966,Thị trấn Nam Giang,362
+13969,Xã Nam Mỹ,362
+13972,Xã Điền Xá,362
+13975,Xã Nghĩa An,362
+13978,Xã Nam Thắng,362
+13981,Xã Nam Toàn,362
+13984,Xã Hồng Quang,362
+13987,Xã Tân Thịnh,362
+13990,Xã Nam Cường,362
+13993,Xã Nam Hồng,362
+13996,Xã Nam Hùng,362
+13999,Xã Nam Hoa,362
+14002,Xã Nam Dương,362
+14005,Xã Nam Thanh,362
+14008,Xã Nam Lợi,362
+14011,Xã Bình Minh,362
+14014,Xã Đồng Sơn,362
+14017,Xã Nam Tiến,362
+14020,Xã Nam Hải,362
+14023,Xã Nam Thái,362
+14026,Thị trấn Cổ Lễ,363
+14029,Xã Phương Định,363
+14032,Xã Trực Chính,363
+14035,Xã Trung Đông,363
+14038,Xã Liêm Hải,363
+14041,Xã Trực Tuấn,363
+14044,Xã Việt Hùng,363
+14047,Xã Trực Đạo,363
+14050,Xã Trực Hưng,363
+14053,Xã Trực Nội,363
+14056,Thị trấn Cát Thành,363
+14059,Xã Trực Thanh,363
+14062,Xã Trực Khang,363
+14065,Xã Trực Thuận,363
+14068,Xã Trực Mỹ,363
+14071,Xã Trực Đại,363
+14074,Xã Trực Cường,363
+14077,Thị trấn Ninh Cường,363
+14080,Xã Trực Thái,363
+14083,Xã Trực Hùng,363
+14086,Xã Trực Thắng,363
+14089,Thị trấn Xuân Trường,364
+14092,Xã Xuân Châu,364
+14095,Xã Xuân Hồng,364
+14098,Xã Xuân Thành,364
+14101,Xã Xuân Thượng,364
+14104,Xã Xuân Phong,364
+14107,Xã Xuân Đài,364
+14110,Xã Xuân Tân,364
+14113,Xã Xuân Thủy,364
+14116,Xã Xuân Ngọc,364
+14119,Xã Xuân Bắc,364
+14122,Xã Xuân Phương,364
+14125,Xã Thọ Nghiệp,364
+14128,Xã Xuân Phú,364
+14131,Xã Xuân Trung,364
+14134,Xã Xuân Vinh,364
+14137,Xã Xuân Kiên,364
+14140,Xã Xuân Tiến,364
+14143,Xã Xuân Ninh,364
+14146,Xã Xuân Hòa,364
+14149,Thị trấn Ngô Đồng,365
+14152,Thị trấn Quất Lâm,365
+14155,Xã Giao Hương,365
+14158,Xã Hồng Thuận,365
+14161,Xã Giao Thiện,365
+14164,Xã Giao Thanh,365
+14167,Xã Hoành Sơn,365
+14170,Xã Bình Hòa,365
+14173,Xã Giao Tiến,365
+14176,Xã Giao Hà,365
+14179,Xã Giao Nhân,365
+14182,Xã Giao An,365
+14185,Xã Giao Lạc,365
+14188,Xã Giao Châu,365
+14191,Xã Giao Tân,365
+14194,Xã Giao Yến,365
+14197,Xã Giao Xuân,365
+14200,Xã Giao Thịnh,365
+14203,Xã Giao Hải,365
+14206,Xã Bạch Long,365
+14209,Xã Giao Long,365
+14212,Xã Giao Phong,365
+14215,Thị trấn Yên Định,366
+14218,Thị trấn Cồn,366
+14221,Thị trấn Thịnh Long,366
+14224,Xã Hải Nam,366
+14227,Xã Hải Trung,366
+14230,Xã Hải Vân,366
+14233,Xã Hải Minh,366
+14236,Xã Hải Anh,366
+14239,Xã Hải Hưng,366
+14242,Xã Hải Bắc,366
+14245,Xã Hải Phúc,366
+14248,Xã Hải Thanh,366
+14251,Xã Hải Hà,366
+14254,Xã Hải Long,366
+14257,Xã Hải Phương,366
+14260,Xã Hải Đường,366
+14263,Xã Hải Lộc,366
+14266,Xã Hải Quang,366
+14269,Xã Hải Đông,366
+14272,Xã Hải Sơn,366
+14275,Xã Hải Tân,366
+14281,Xã Hải Phong,366
+14284,Xã Hải An,366
+14287,Xã Hải Tây,366
+14290,Xã Hải Lý,366
+14293,Xã Hải Phú,366
+14296,Xã Hải Giang,366
+14299,Xã Hải Cường,366
+14302,Xã Hải Ninh,366
+14305,Xã Hải Chính,366
+14308,Xã Hải Xuân,366
+14311,Xã Hải Châu,366
+14314,Xã Hải Triều,366
+14317,Xã Hải Hòa,366
+14320,Phường Đông Thành,369
+14323,Phường Tân Thành,369
+14326,Phường Thanh Bình,369
+14329,Phường Vân Giang,369
+14332,Phường Bích Đào,369
+14335,Phường Phúc Thành,369
+14338,Phường Nam Bình,369
+14341,Phường Nam Thành,369
+14344,Phường Ninh Khánh,369
+14347,Xã Ninh Nhất,369
+14350,Xã Ninh Tiến,369
+14353,Xã Ninh Phúc,369
+14356,Phường Ninh Sơn,369
+14359,Phường Ninh Phong,369
+14362,Phường Bắc Sơn,370
+14365,Phường Trung Sơn,370
+14368,Phường Nam Sơn,370
+14369,Phường Tây Sơn,370
+14371,Xã Yên Sơn,370
+14374,Phường Yên Bình,370
+14375,Phường Tân Bình,370
+14377,Xã Quang Sơn,370
+14380,Xã Đông Sơn,370
+14383,Thị trấn Nho Quan,372
+14386,Xã Xích Thổ,372
+14389,Xã Gia Lâm,372
+14392,Xã Gia Sơn,372
+14395,Xã Thạch Bình,372
+14398,Xã Gia Thủy,372
+14401,Xã Gia Tường,372
+14404,Xã Cúc Phương,372
+14407,Xã Phú Sơn,372
+14410,Xã Đức Long,372
+14413,Xã Lạc Vân,372
+14416,Xã Đồng Phong,372
+14419,Xã Yên Quang,372
+14422,Xã Lạng Phong,372
+14425,Xã Thượng Hòa,372
+14428,Xã Văn Phong,372
+14431,Xã Văn Phương,372
+14434,Xã Thanh Lạc,372
+14437,Xã Sơn Lai,372
+14440,Xã Sơn Thành,372
+14443,Xã Văn Phú,372
+14446,Xã Phú Lộc,372
+14449,Xã Kỳ Phú,372
+14452,Xã Quỳnh Lưu,372
+14455,Xã Sơn Hà,372
+14458,Xã Phú Long,372
+14461,Xã Quảng Lạc,372
+14464,Thị trấn Me,373
+14467,Xã Gia Hòa,373
+14470,Xã Gia Hưng,373
+14473,Xã Liên Sơn,373
+14476,Xã Gia Thanh,373
+14479,Xã Gia Vân,373
+14482,Xã Gia Phú,373
+14485,Xã Gia Xuân,373
+14488,Xã Gia Lập,373
+14491,Xã Gia Vượng,373
+14494,Xã Gia Trấn,373
+14497,Xã Gia Thịnh,373
+14500,Xã Gia Phương,373
+14503,Xã Gia Tân,373
+14506,Xã Gia Thắng,373
+14509,Xã Gia Trung,373
+14512,Xã Gia Minh,373
+14515,Xã Gia Lạc,373
+14518,Xã Gia Tiến,373
+14521,Xã Gia Sinh,373
+14524,Xã Gia Phong,373
+14527,Thị trấn Thiên Tôn,374
+14530,Xã Ninh Giang,374
+14533,Xã Trường Yên,374
+14536,Xã Ninh Khang,374
+14539,Xã Ninh Mỹ,374
+14542,Xã Ninh Hòa,374
+14545,Xã Ninh Xuân,374
+14548,Xã Ninh Hải,374
+14551,Xã Ninh Thắng,374
+14554,Xã Ninh Vân,374
+14557,Xã Ninh An,374
+14560,Thị trấn Yên Ninh,375
+14563,Xã Khánh Tiên,375
+14566,Xã Khánh Phú,375
+14569,Xã Khánh Hòa,375
+14572,Xã Khánh Lợi,375
+14575,Xã Khánh An,375
+14578,Xã Khánh Cường,375
+14581,Xã Khánh Cư,375
+14584,Xã Khánh Thiện,375
+14587,Xã Khánh Hải,375
+14590,Xã Khánh Trung,375
+14593,Xã Khánh Mậu,375
+14596,Xã Khánh Vân,375
+14599,Xã Khánh Hội,375
+14602,Xã Khánh Công,375
+14608,Xã Khánh Thành,375
+14611,Xã Khánh Nhạc,375
+14614,Xã Khánh Thủy,375
+14617,Xã Khánh Hồng,375
+14620,Thị trấn Phát Diệm,376
+14623,Thị trấn Bình Minh,376
+14629,Xã Hồi Ninh,376
+14632,Xã Xuân Chính,376
+14635,Xã Kim Định,376
+14638,Xã Ân Hòa,376
+14641,Xã Hùng Tiến,376
+14647,Xã Quang Thiện,376
+14650,Xã Như Hòa,376
+14653,Xã Chất Bình,376
+14656,Xã Đồng Hướng,376
+14659,Xã Kim Chính,376
+14662,Xã Thượng Kiệm,376
+14665,Xã Lưu Phương,376
+14668,Xã Tân Thành,376
+14671,Xã Yên Lộc,376
+14674,Xã Lai Thành,376
+14677,Xã Định Hóa,376
+14680,Xã Văn Hải,376
+14683,Xã Kim Tân,376
+14686,Xã Kim Mỹ,376
+14689,Xã Cồn Thoi,376
+14692,Xã Kim Hải,376
+14695,Xã Kim Trung,376
+14698,Xã Kim Đông,376
+14701,Thị trấn Yên Thịnh,377
+14704,Xã Khánh Thượng,377
+14707,Xã Khánh Dương,377
+14710,Xã Mai Sơn,377
+14713,Xã Khánh Thịnh,377
+14719,Xã Yên Phong,377
+14722,Xã Yên Hòa,377
+14725,Xã Yên Thắng,377
+14728,Xã Yên Từ,377
+14731,Xã Yên Hưng,377
+14734,Xã Yên Thành,377
+14737,Xã Yên Nhân,377
+14740,Xã Yên Mỹ,377
+14743,Xã Yên Mạc,377
+14746,Xã Yên Đồng,377
+14749,Xã Yên Thái,377
+14752,Xã Yên Lâm,377
+14755,Phường Hàm Rồng,380
+14758,Phường Đông Thọ,380
+14761,Phường Nam Ngạn,380
+14764,Phường Trường Thi,380
+14767,Phường Điện Biên,380
+14770,Phường Phú Sơn,380
+14773,Phường Lam Sơn,380
+14776,Phường Ba Đình,380
+14779,Phường Ngọc Trạo,380
+14782,Phường Đông Vệ,380
+14785,Phường Đông Sơn,380
+14788,Phường Tân Sơn,380
+14791,Phường Đông Cương,380
+14794,Phường Đông Hương,380
+14797,Phường Đông Hải,380
+14800,Phường Quảng Hưng,380
+14803,Phường Quảng Thắng,380
+14806,Phường Quảng Thành,380
+15850,Xã Thiệu Vân,380
+15856,Phường Thiệu Khánh,380
+15859,Phường Thiệu Dương,380
+15913,Phường Tào Xuyên,380
+15922,Phường Long Anh,380
+15925,Xã Hoằng Quang,380
+15970,Xã Hoằng Đại,380
+16396,Phường Đông Lĩnh,380
+16429,Xã Đông Vinh,380
+16432,Phường Đông Tân,380
+16435,Phường An Hưng,380
+16441,Phường Quảng Thịnh,380
+16459,Phường Quảng Đông,380
+16507,Phường Quảng Cát,380
+16522,Phường Quảng Phú,380
+16525,Phường Quảng Tâm,380
+14809,Phường Bắc Sơn,381
+14812,Phường Ba Đình,381
+14815,Phường Lam Sơn,381
+14818,Phường Ngọc Trạo,381
+14821,Phường Đông Sơn,381
+14823,Phường Phú Sơn,381
+14824,Xã Quang Trung,381
+14830,Phường Trung Sơn,382
+14833,Phường Bắc Sơn,382
+14836,Phường Trường Sơn,382
+14839,Phường Quảng Cư,382
+14842,Phường Quảng Tiến,382
+16513,Xã Quảng Minh,382
+16516,Xã Quảng Hùng,382
+16528,Phường Quảng Thọ,382
+16531,Phường Quảng Châu,382
+16534,Phường Quảng Vinh,382
+16537,Xã Quảng Đại,382
+14845,Thị trấn Mường Lát,384
+14848,Xã Tam Chung,384
+14854,Xã Mường Lý,384
+14857,Xã Trung Lý,384
+14860,Xã Quang Chiểu,384
+14863,Xã Pù Nhi,384
+14864,Xã Nhi Sơn,384
+14866,Xã Mường Chanh,384
+14869,Thị trấn Hồi Xuân,385
+14872,Xã Thành Sơn,385
+14875,Xã Trung Sơn,385
+14878,Xã Phú Thanh,385
+14881,Xã Trung Thành,385
+14884,Xã Phú Lệ,385
+14887,Xã Phú Sơn,385
+14890,Xã Phú Xuân,385
+14896,Xã Hiền Chung,385
+14899,Xã Hiền Kiệt,385
+14902,Xã Nam Tiến,385
+14908,Xã Thiên Phủ,385
+14911,Xã Phú Nghiêm,385
+14914,Xã Nam Xuân,385
+14917,Xã Nam Động,385
+14923,Thị trấn Cành Nàng,386
+14926,Xã Điền Thượng,386
+14929,Xã Điền Hạ,386
+14932,Xã Điền Quang,386
+14935,Xã Điền Trung,386
+14938,Xã Thành Sơn,386
+14941,Xã Lương Ngoại,386
+14944,Xã Ái Thượng,386
+14947,Xã Lương Nội,386
+14950,Xã Điền Lư,386
+14953,Xã Lương Trung,386
+14956,Xã Lũng Niêm,386
+14959,Xã Lũng Cao,386
+14962,Xã Hạ Trung,386
+14965,Xã Cổ Lũng,386
+14968,Xã Thành Lâm,386
+14971,Xã Ban Công,386
+14974,Xã Kỳ Tân,386
+14977,Xã Văn Nho,386
+14980,Xã Thiết Ống,386
+14986,Xã Thiết Kế,386
+14995,Xã Trung Xuân,387
+14998,Xã Trung Thượng,387
+14999,Xã Trung Tiến,387
+15001,Xã Trung Hạ,387
+15004,Xã Sơn Hà,387
+15007,Xã Tam Thanh,387
+15010,Xã Sơn Thủy,387
+15013,Xã Na Mèo,387
+15016,Thị trấn Sơn Lư,387
+15019,Xã Tam Lư,387
+15022,Xã Sơn Điện,387
+15025,Xã Mường Mìn,387
+15031,Xã Yên Khương,388
+15034,Xã Yên Thắng,388
+15037,Xã Trí Nang,388
+15040,Xã Giao An,388
+15043,Xã Giao Thiện,388
+15046,Xã Tân Phúc,388
+15049,Xã Tam Văn,388
+15052,Xã Lâm Phú,388
+15055,Thị trấn Lang Chánh,388
+15058,Xã Đồng Lương,388
+15061,Thị Trấn Ngọc Lặc,389
+15064,Xã Lam Sơn,389
+15067,Xã Mỹ Tân,389
+15070,Xã Thúy Sơn,389
+15073,Xã Thạch Lập,389
+15076,Xã Vân Âm,389
+15079,Xã Cao Ngọc,389
+15085,Xã Quang Trung,389
+15088,Xã Đồng Thịnh,389
+15091,Xã Ngọc Liên,389
+15094,Xã Ngọc Sơn,389
+15097,Xã Lộc Thịnh,389
+15100,Xã Cao Thịnh,389
+15103,Xã Ngọc Trung,389
+15106,Xã Phùng Giáo,389
+15109,Xã Phùng Minh,389
+15112,Xã Phúc Thịnh,389
+15115,Xã Nguyệt Ấn,389
+15118,Xã Kiên Thọ,389
+15121,Xã Minh Tiến,389
+15124,Xã Minh Sơn,389
+15127,Thị trấn Phong Sơn,390
+15133,Xã Cẩm Thành,390
+15136,Xã Cẩm Quý,390
+15139,Xã Cẩm Lương,390
+15142,Xã Cẩm Thạch,390
+15145,Xã Cẩm Liên,390
+15148,Xã Cẩm Giang,390
+15151,Xã Cẩm Bình,390
+15154,Xã Cẩm Tú,390
+15160,Xã Cẩm Châu,390
+15163,Xã Cẩm Tâm,390
+15169,Xã Cẩm Ngọc,390
+15172,Xã Cẩm Long,390
+15175,Xã Cẩm Yên,390
+15178,Xã Cẩm Tân,390
+15181,Xã Cẩm Phú,390
+15184,Xã Cẩm Vân,390
+15187,Thị trấn Kim Tân,391
+15190,Thị trấn Vân Du,391
+15196,Xã Thạch Lâm,391
+15199,Xã Thạch Quảng,391
+15202,Xã Thạch Tượng,391
+15205,Xã Thạch Cẩm,391
+15208,Xã Thạch Sơn,391
+15211,Xã Thạch Bình,391
+15214,Xã Thạch Định,391
+15217,Xã Thạch Đồng,391
+15220,Xã Thạch Long,391
+15223,Xã Thành Mỹ,391
+15226,Xã Thành Yên,391
+15229,Xã Thành Vinh,391
+15232,Xã Thành Minh,391
+15235,Xã Thành Công,391
+15238,Xã Thành Tân,391
+15241,Xã Thành Trực,391
+15247,Xã Thành Tâm,391
+15250,Xã Thành An,391
+15253,Xã Thành Thọ,391
+15256,Xã Thành Tiến,391
+15259,Xã Thành Long,391
+15265,Xã Thành Hưng,391
+15268,Xã Ngọc Trạo,391
+15271,Thị trấn Hà Trung,392
+15274,Xã Hà Long,392
+15277,Xã Hà Vinh,392
+15280,Xã Hà Bắc,392
+15283,Xã Hoạt Giang,392
+15286,Xã Yên Dương,392
+15292,Xã Hà Giang,392
+15298,Xã Lĩnh Toại,392
+15304,Xã Hà Ngọc,392
+15307,Xã Yến Sơn,392
+15313,Xã Hà Sơn,392
+15316,Xã Hà Lĩnh,392
+15319,Xã Hà Đông,392
+15322,Xã Hà Tân,392
+15325,Xã Hà Tiến,392
+15328,Xã Hà Bình,392
+15331,Xã Hà Lai,392
+15334,Xã Hà Châu,392
+15340,Xã Hà Thái,392
+15343,Xã Hà Hải,392
+15349,Thị trấn Vĩnh Lộc,393
+15352,Xã Vĩnh Quang,393
+15355,Xã Vĩnh Yên,393
+15358,Xã Vĩnh Tiến,393
+15361,Xã Vĩnh Long,393
+15364,Xã Vĩnh Phúc,393
+15367,Xã Vĩnh Hưng,393
+15376,Xã Vĩnh Hòa,393
+15379,Xã Vĩnh Hùng,393
+15382,Xã Minh Tân,393
+15385,Xã Ninh Khang,393
+15388,Xã Vĩnh Thịnh,393
+15391,Xã Vĩnh An,393
+15397,Thị trấn Thống Nhất,394
+15403,Thị trấn Yên Lâm,394
+15406,Xã Yên Tâm,394
+15409,Xã Yên Phú,394
+15412,Thị trấn Quý Lộc,394
+15415,Xã Yên Thọ,394
+15418,Xã Yên Trung,394
+15421,Xã Yên Trường,394
+15427,Xã Yên Phong,394
+15430,Xã Yên Thái,394
+15433,Xã Yên Hùng,394
+15436,Xã Yên Thịnh,394
+15439,Xã Yên Ninh,394
+15442,Xã Yên Lạc,394
+15445,Xã Định Tăng,394
+15448,Xã Định Hòa,394
+15451,Xã Định Thành,394
+15454,Xã Định Công,394
+15457,Xã Định Tân,394
+15460,Xã Định Tiến,394
+15463,Xã Định Long,394
+15466,Xã Định Liên,394
+15469,Thị trấn Quán Lào,394
+15472,Xã Định Hưng,394
+15475,Xã Định Hải,394
+15478,Xã Định Bình,394
+15493,Xã Xuân Hồng,395
+15499,Thị trấn Thọ Xuân,395
+15502,Xã Bắc Lương,395
+15505,Xã Nam Giang,395
+15508,Xã Xuân Phong,395
+15511,Xã Thọ Lộc,395
+15514,Xã Xuân Trường,395
+15517,Xã Xuân Hòa,395
+15520,Xã Thọ Hải,395
+15523,Xã Tây Hồ,395
+15526,Xã Xuân Giang,395
+15532,Xã Xuân Sinh,395
+15535,Xã Xuân Hưng,395
+15538,Xã Thọ Diên,395
+15541,Xã Thọ Lâm,395
+15544,Xã Thọ Xương,395
+15547,Xã Xuân Bái,395
+15550,Xã Xuân Phú,395
+15553,Thị trấn Sao Vàng,395
+15556,Thị trấn Lam Sơn,395
+15559,Xã Xuân Thiên,395
+15565,Xã Thuận Minh,395
+15568,Xã Thọ Lập,395
+15571,Xã Quảng Phú,395
+15574,Xã Xuân Tín,395
+15577,Xã Phú Xuân,395
+15583,Xã Xuân Lai,395
+15586,Xã Xuân Lập,395
+15592,Xã Xuân Minh,395
+15598,Xã Trường Xuân,395
+15607,Xã Bát Mọt,396
+15610,Xã Yên Nhân,396
+15619,Xã Xuân Lẹ,396
+15622,Xã Vạn Xuân,396
+15628,Xã Lương Sơn,396
+15631,Xã Xuân Cao,396
+15634,Xã Luận Thành,396
+15637,Xã Luận Khê,396
+15640,Xã Xuân Thắng,396
+15643,Xã Xuân Lộc,396
+15646,Thị trấn Thường Xuân,396
+15649,Xã Xuân Dương,396
+15652,Xã Thọ Thanh,396
+15655,Xã Ngọc Phụng,396
+15658,Xã Xuân Chinh,396
+15661,Xã Tân Thành,396
+15664,Thị trấn Triệu Sơn,397
+15667,Xã Thọ Sơn,397
+15670,Xã Thọ Bình,397
+15673,Xã Thọ Tiến,397
+15676,Xã Hợp Lý,397
+15679,Xã Hợp Tiến,397
+15682,Xã Hợp Thành,397
+15685,Xã Triệu Thành,397
+15688,Xã Hợp Thắng,397
+15691,Xã Minh Sơn,397
+15700,Xã Dân Lực,397
+15703,Xã Dân Lý,397
+15706,Xã Dân Quyền,397
+15709,Xã An Nông,397
+15712,Xã Văn Sơn,397
+15715,Xã Thái Hòa,397
+15718,Thị trấn Nưa,397
+15721,Xã Đồng Lợi,397
+15724,Xã Đồng Tiến,397
+15727,Xã Đồng Thắng,397
+15730,Xã Tiến Nông,397
+15733,Xã Khuyến Nông,397
+15736,Xã Xuân Thịnh,397
+15739,Xã Xuân Lộc,397
+15742,Xã Thọ Dân,397
+15745,Xã Xuân Thọ,397
+15748,Xã Thọ Tân,397
+15751,Xã Thọ Ngọc,397
+15754,Xã Thọ Cường,397
+15757,Xã Thọ Phú,397
+15760,Xã Thọ Vực,397
+15763,Xã Thọ Thế,397
+15766,Xã Nông Trường,397
+15769,Xã Bình Sơn,397
+15772,Thị trấn Thiệu Hóa,398
+15775,Xã Thiệu Ngọc,398
+15778,Xã Thiệu Vũ,398
+15781,Xã Thiệu Phúc,398
+15784,Xã Thiệu Tiến,398
+15787,Xã Thiệu Công,398
+15790,Xã Thiệu Phú,398
+15793,Xã Thiệu Long,398
+15796,Xã Thiệu Giang,398
+15799,Xã Thiệu Duy,398
+15802,Xã Thiệu Nguyên,398
+15805,Xã Thiệu Hợp,398
+15808,Xã Thiệu Thịnh,398
+15811,Xã Thiệu Quang,398
+15814,Xã Thiệu Thành,398
+15817,Xã Thiệu Toán,398
+15820,Xã Thiệu Chính,398
+15823,Xã Thiệu Hòa,398
+15829,Xã Minh Tâm,398
+15832,Xã Thiệu Viên,398
+15835,Xã Thiệu Lý,398
+15838,Xã Thiệu Vận,398
+15841,Xã Thiệu Trung,398
+15847,Xã Tân Châu,398
+15853,Xã Thiệu Giao,398
+15865,Thị trấn Bút Sơn,399
+15871,Xã Hoằng Giang,399
+15877,Xã Hoằng Xuân,399
+15880,Xã Hoằng Phượng,399
+15883,Xã Hoằng Phú,399
+15886,Xã Hoằng Quỳ,399
+15889,Xã Hoằng Kim,399
+15892,Xã Hoằng Trung,399
+15895,Xã Hoằng Trinh,399
+15901,Xã Hoằng Sơn,399
+15907,Xã Hoằng Cát,399
+15910,Xã Hoằng Xuyên,399
+15916,Xã Hoằng Quý,399
+15919,Xã Hoằng Hợp,399
+15928,Xã Hoằng Đức,399
+15937,Xã Hoằng Hà,399
+15940,Xã Hoằng Đạt,399
+15946,Xã Hoằng Đạo,399
+15949,Xã Hoằng Thắng,399
+15952,Xã Hoằng Đồng,399
+15955,Xã Hoằng Thái,399
+15958,Xã Hoằng Thịnh,399
+15961,Xã Hoằng Thành,399
+15964,Xã Hoằng Lộc,399
+15967,Xã Hoằng Trạch,399
+15973,Xã Hoằng Phong,399
+15976,Xã Hoằng Lưu,399
+15979,Xã Hoằng Châu,399
+15982,Xã Hoằng Tân,399
+15985,Xã Hoằng Yến,399
+15988,Xã Hoằng Tiến,399
+15991,Xã Hoằng Hải,399
+15994,Xã Hoằng Ngọc,399
+15997,Xã Hoằng Đông,399
+16000,Xã Hoằng Thanh,399
+16003,Xã Hoằng Phụ,399
+16006,Xã Hoằng Trường,399
+16012,Thị trấn Hậu Lộc,400
+16015,Xã Đồng Lộc,400
+16018,Xã Đại Lộc,400
+16021,Xã Triệu Lộc,400
+16027,Xã Tiến Lộc,400
+16030,Xã Lộc Sơn,400
+16033,Xã Cầu Lộc,400
+16036,Xã Thành Lộc,400
+16039,Xã Tuy Lộc,400
+16042,Xã Phong Lộc,400
+16045,Xã Mỹ Lộc,400
+16048,Xã Thuần Lộc,400
+16057,Xã Xuân Lộc,400
+16063,Xã Hoa Lộc,400
+16066,Xã Liên Lộc,400
+16069,Xã Quang Lộc,400
+16072,Xã Phú Lộc,400
+16075,Xã Hòa Lộc,400
+16078,Xã Minh Lộc,400
+16081,Xã Hưng Lộc,400
+16084,Xã Hải Lộc,400
+16087,Xã Đa Lộc,400
+16090,Xã Ngư Lộc,400
+16093,Thị trấn Nga Sơn,401
+16096,Xã Ba Đình,401
+16099,Xã Nga Vịnh,401
+16102,Xã Nga Văn,401
+16105,Xã Nga Thiện,401
+16108,Xã Nga Tiến,401
+16114,Xã Nga Phượng,401
+16117,Xã Nga Trung,401
+16120,Xã Nga Bạch,401
+16123,Xã Nga Thanh,401
+16132,Xã Nga Yên,401
+16135,Xã Nga Giáp,401
+16138,Xã Nga Hải,401
+16141,Xã Nga Thành,401
+16144,Xã Nga An,401
+16147,Xã Nga Phú,401
+16150,Xã Nga Điền,401
+16153,Xã Nga Tân,401
+16156,Xã Nga Thủy,401
+16159,Xã Nga Liên,401
+16162,Xã Nga Thái,401
+16165,Xã Nga Thạch,401
+16168,Xã Nga Thắng,401
+16171,Xã Nga Trường,401
+16174,Thị trấn Yên Cát,402
+16177,Xã Bãi Trành,402
+16180,Xã Xuân Hòa,402
+16183,Xã Xuân Bình,402
+16186,Xã Hóa Quỳ,402
+16195,Xã Cát Vân,402
+16198,Xã Cát Tân,402
+16201,Xã Tân Bình,402
+16204,Xã Bình Lương,402
+16207,Xã Thanh Quân,402
+16210,Xã Thanh Xuân,402
+16213,Xã Thanh Hòa,402
+16216,Xã Thanh Phong,402
+16219,Xã Thanh Lâm,402
+16222,Xã Thanh Sơn,402
+16225,Xã Thượng Ninh,402
+16228,Thị trấn Bến Sung,403
+16231,Xã Cán Khê,403
+16234,Xã Xuân Du,403
+16240,Xã Phượng Nghi,403
+16243,Xã Mậu Lâm,403
+16246,Xã Xuân Khang,403
+16249,Xã Phú Nhuận,403
+16252,Xã Hải Long,403
+16258,Xã Xuân Thái,403
+16261,Xã Xuân Phúc,403
+16264,Xã Yên Thọ,403
+16267,Xã Yên Lạc,403
+16273,Xã Thanh Tân,403
+16276,Xã Thanh Kỳ,403
+16279,Thị trấn Nông Cống,404
+16282,Xã Tân Phúc,404
+16285,Xã Tân Thọ,404
+16288,Xã Hoàng Sơn,404
+16291,Xã Tân Khang,404
+16294,Xã Hoàng Giang,404
+16297,Xã Trung Chính,404
+16303,Xã Trung Thành,404
+16309,Xã Tế Thắng,404
+16315,Xã Tế Lợi,404
+16318,Xã Tế Nông,404
+16321,Xã Minh Nghĩa,404
+16324,Xã Minh Khôi,404
+16327,Xã Vạn Hòa,404
+16330,Xã Trường Trung,404
+16333,Xã Vạn Thắng,404
+16336,Xã Trường Giang,404
+16339,Xã Vạn Thiện,404
+16342,Xã Thăng Long,404
+16345,Xã Trường Minh,404
+16348,Xã Trường Sơn,404
+16351,Xã Thăng Bình,404
+16354,Xã Công Liêm,404
+16357,Xã Tượng Văn,404
+16360,Xã Thăng Thọ,404
+16363,Xã Tượng Lĩnh,404
+16366,Xã Tượng Sơn,404
+16369,Xã Công Chính,404
+16375,Xã Yên Mỹ,404
+16378,Thị trấn Rừng Thông,405
+16381,Xã Đông Hoàng,405
+16384,Xã Đông Ninh,405
+16390,Xã Đông Hòa,405
+16393,Xã Đông Yên,405
+16399,Xã Đông Minh,405
+16402,Xã Đông Thanh,405
+16405,Xã Đông Tiến,405
+16408,Xã Đông Khê,405
+16414,Xã Đông Thịnh,405
+16417,Xã Đông Văn,405
+16420,Xã Đông Phú,405
+16423,Xã Đông Nam,405
+16426,Xã Đông Quang,405
+16438,Thị trấn Tân Phong,406
+16447,Xã Quảng Trạch,406
+16453,Xã Quảng Đức,406
+16456,Xã Quảng Định,406
+16462,Xã Quảng Nhân,406
+16465,Xã Quảng Ninh,406
+16468,Xã Quảng Bình,406
+16471,Xã Quảng Hợp,406
+16474,Xã Quảng Văn,406
+16477,Xã Quảng Long,406
+16480,Xã Quảng Yên,406
+16483,Xã Quảng Hòa,406
+16489,Xã Quảng Khê,406
+16492,Xã Quảng Trung,406
+16495,Xã Quảng Chính,406
+16498,Xã Quảng Ngọc,406
+16501,Xã Quảng Trường,406
+16510,Xã Quảng Phúc,406
+16519,Xã Quảng Giao,406
+16540,Xã Quảng Hải,406
+16543,Xã Quảng Lưu,406
+16546,Xã Quảng Lộc,406
+16549,Xã Tiên Trang,406
+16552,Xã Quảng Nham,406
+16555,Xã Quảng Thạch,406
+16558,Xã Quảng Thái,406
+16561,Phường Hải Hòa,407
+16564,Phường Hải Châu,407
+16567,Xã Thanh Thủy,407
+16570,Xã Thanh Sơn,407
+16576,Phường Hải Ninh,407
+16579,Xã Anh Sơn,407
+16582,Xã Ngọc Lĩnh,407
+16585,Phường Hải An,407
+16591,Xã Các Sơn,407
+16594,Phường Tân Dân,407
+16597,Phường Hải Lĩnh,407
+16600,Xã Định Hải,407
+16603,Xã Phú Sơn,407
+16606,Phường Ninh Hải,407
+16609,Phường Nguyên Bình,407
+16612,Xã Hải Nhân,407
+16618,Phường Bình Minh,407
+16621,Phường Hải Thanh,407
+16624,Xã Phú Lâm,407
+16627,Phường Xuân Lâm,407
+16630,Phường Trúc Lâm,407
+16633,Phường Hải Bình,407
+16636,Xã Tân Trường,407
+16639,Xã Tùng Lâm,407
+16642,Phường Tĩnh Hải,407
+16645,Phường Mai Lâm,407
+16648,Xã Trường Lâm,407
+16651,Xã Hải Yến,407
+16654,Phường Hải Thượng,407
+16657,Xã Nghi Sơn,407
+16660,Xã Hải Hà,407
+16663,Phường Đông Vĩnh,412
+16666,Phường Hà Huy Tập,412
+16669,Phường Lê Lợi,412
+16670,Phường Quán Bàu,412
+16672,Phường Hưng Bình,412
+16673,Phường Hưng Phúc,412
+16675,Phường Hưng Dũng,412
+16678,Phường Cửa Nam,412
+16681,Phường Quang Trung,412
+16684,Phường Đội Cung,412
+16687,Phường Lê Mao,412
+16690,Phường Trường Thi,412
+16693,Phường Bến Thủy,412
+16696,Phường Hồng Sơn,412
+16699,Phường Trung Đô,412
+16702,Xã Nghi Phú,412
+16705,Xã Hưng Đông,412
+16708,Xã Hưng Lộc,412
+16711,Xã Hưng Hòa,412
+16714,Phường Vinh Tân,412
+17908,Xã Nghi Liên,412
+17914,Xã Nghi Ân,412
+17920,Xã Nghi Kim,412
+17923,Xã Nghi Đức,412
+18013,Xã Hưng Chính,412
+16717,Phường Nghi Thuỷ,413
+16720,Phường Nghi Tân,413
+16723,Phường Thu Thuỷ,413
+16726,Phường Nghi Hòa,413
+16729,Phường Nghi Hải,413
+16732,Phường Nghi Hương,413
+16735,Phường Nghi Thu,413
+16939,Phường Hoà Hiếu,414
+16993,Phường Quang Phong,414
+16994,Phường Quang Tiến,414
+17003,Phường Long Sơn,414
+17005,Xã Nghĩa Tiến,414
+17008,Xã Nghĩa Mỹ,414
+17011,Xã Tây Hiếu,414
+17014,Xã Nghĩa Thuận,414
+17017,Xã Đông Hiếu,414
+16738,Thị trấn Kim Sơn,415
+16741,Xã Thông Thụ,415
+16744,Xã Đồng Văn,415
+16747,Xã Hạnh Dịch,415
+16750,Xã Tiền Phong,415
+16753,Xã Nậm Giải,415
+16756,Xã Tri Lễ,415
+16759,Xã Châu Kim,415
+16763,Xã Mường Nọc,415
+16765,Xã Châu Thôn,415
+16768,Xã Nậm Nhoóng,415
+16771,Xã Quang Phong,415
+16774,Xã Căm Muộn,415
+16777,Thị trấn Tân Lạc,416
+16780,Xã Châu Bính,416
+16783,Xã Châu Thuận,416
+16786,Xã Châu Hội,416
+16789,Xã Châu Nga,416
+16792,Xã Châu Tiến,416
+16795,Xã Châu Hạnh,416
+16798,Xã Châu Thắng,416
+16801,Xã Châu Phong,416
+16804,Xã Châu Bình,416
+16807,Xã Châu Hoàn,416
+16810,Xã Diên Lãm,416
+16813,Thị trấn Mường Xén,417
+16816,Xã Mỹ Lý,417
+16819,Xã Bắc Lý,417
+16822,Xã Keng Đu,417
+16825,Xã Đoọc Mạy,417
+16828,Xã Huồi Tụ,417
+16831,Xã Mường Lống,417
+16834,Xã Na Loi,417
+16837,Xã Nậm Cắn,417
+16840,Xã Bảo Nam,417
+16843,Xã Phà Đánh,417
+16846,Xã Bảo Thắng,417
+16849,Xã Hữu Lập,417
+16852,Xã Tà Cạ,417
+16855,Xã Chiêu Lưu,417
+16858,Xã Mường Típ,417
+16861,Xã Hữu Kiệm,417
+16864,Xã Tây Sơn,417
+16867,Xã Mường Ải,417
+16870,Xã Na Ngoi,417
+16873,Xã Nậm Càn,417
+16876,Thị trấn Thạch Giám,418
+16879,Xã Mai Sơn,418
+16882,Xã Nhôn Mai,418
+16885,Xã Hữu Khuông,418
+16900,Xã Yên Tĩnh,418
+16903,Xã Nga My,418
+16904,Xã Xiêng My,418
+16906,Xã Lưỡng Minh,418
+16909,Xã Yên Hòa,418
+16912,Xã Yên Na,418
+16915,Xã Lưu Kiền,418
+16921,Xã Xá Lượng,418
+16924,Xã Tam Thái,418
+16927,Xã Tam Đình,418
+16930,Xã Yên Thắng,418
+16933,Xã Tam Quang,418
+16936,Xã Tam Hợp,418
+16941,Thị trấn Nghĩa Đàn,419
+16942,Xã Nghĩa Mai,419
+16945,Xã Nghĩa Yên,419
+16948,Xã Nghĩa Lạc,419
+16951,Xã Nghĩa Lâm,419
+16954,Xã Nghĩa Sơn,419
+16957,Xã Nghĩa Lợi,419
+16960,Xã Nghĩa Bình,419
+16963,Xã Nghĩa Thọ,419
+16966,Xã Nghĩa Minh,419
+16969,Xã Nghĩa Phú,419
+16972,Xã Nghĩa Hưng,419
+16975,Xã Nghĩa Hồng,419
+16978,Xã Nghĩa Thịnh,419
+16981,Xã Nghĩa Trung,419
+16984,Xã Nghĩa Hội,419
+16987,Xã Nghĩa Thành,419
+16996,Xã Nghĩa Hiếu,419
+17020,Xã Nghĩa Đức,419
+17023,Xã Nghĩa An,419
+17026,Xã Nghĩa Long,419
+17029,Xã Nghĩa Lộc,419
+17032,Xã Nghĩa Khánh,419
+17035,Thị trấn Quỳ Hợp,420
+17038,Xã Yên Hợp,420
+17041,Xã Châu Tiến,420
+17044,Xã Châu Hồng,420
+17047,Xã Đồng Hợp,420
+17050,Xã Châu Thành,420
+17053,Xã Liên Hợp,420
+17056,Xã Châu Lộc,420
+17059,Xã Tam Hợp,420
+17062,Xã Châu Cường,420
+17065,Xã Châu Quang,420
+17068,Xã Thọ Hợp,420
+17071,Xã Minh Hợp,420
+17074,Xã Nghĩa Xuân,420
+17077,Xã Châu Thái,420
+17080,Xã Châu Đình,420
+17083,Xã Văn Lợi,420
+17086,Xã Nam Sơn,420
+17089,Xã Châu Lý,420
+17092,Xã Hạ Sơn,420
+17095,Xã Bắc Sơn,420
+17098,Thị trấn Cầu Giát,421
+17101,Xã Quỳnh Thắng,421
+17119,Xã Quỳnh Tân,421
+17122,Xã Quỳnh Châu,421
+17140,Xã Tân Sơn,421
+17143,Xã Quỳnh Văn,421
+17146,Xã Ngọc Sơn,421
+17149,Xã Quỳnh Tam,421
+17152,Xã Quỳnh Hoa,421
+17155,Xã Quỳnh Thạch,421
+17158,Xã Quỳnh Bảng,421
+17161,Xã Quỳnh Mỹ,421
+17164,Xã Quỳnh Thanh,421
+17167,Xã Quỳnh Hậu,421
+17170,Xã Quỳnh Lâm,421
+17173,Xã Quỳnh Đôi,421
+17176,Xã Quỳnh Lương,421
+17179,Xã Quỳnh Hồng,421
+17182,Xã Quỳnh Yên,421
+17185,Xã Quỳnh Bá,421
+17188,Xã Quỳnh Minh,421
+17191,Xã Quỳnh Diễn,421
+17194,Xã Quỳnh Hưng,421
+17197,Xã Quỳnh Giang,421
+17200,Xã Quỳnh Ngọc,421
+17203,Xã Quỳnh Nghĩa,421
+17206,Xã An Hòa,421
+17209,Xã Tiến Thủy,421
+17212,Xã Sơn Hải,421
+17215,Xã Quỳnh Thọ,421
+17218,Xã Quỳnh Thuận,421
+17221,Xã Quỳnh Long,421
+17224,Xã Tân Thắng,421
+17227,Thị trấn Con Cuông,422
+17230,Xã Bình Chuẩn,422
+17233,Xã Lạng Khê,422
+17236,Xã Cam Lâm,422
+17239,Xã Thạch Ngàn,422
+17242,Xã Đôn Phục,422
+17245,Xã Mậu Đức,422
+17248,Xã Châu Khê,422
+17251,Xã Chi Khê,422
+17254,Xã Bồng Khê,422
+17257,Xã Yên Khê,422
+17260,Xã Lục Dạ,422
+17263,Xã Môn Sơn,422
+17266,Thị trấn Tân Kỳ,423
+17269,Xã Tân Hợp,423
+17272,Xã Tân Phú,423
+17275,Xã Tân Xuân,423
+17278,Xã Giai Xuân,423
+17281,Xã Nghĩa Bình,423
+17284,Xã Nghĩa Đồng,423
+17287,Xã Đồng Văn,423
+17290,Xã Nghĩa Thái,423
+17293,Xã Nghĩa Hợp,423
+17296,Xã Nghĩa Hoàn,423
+17299,Xã Nghĩa Phúc,423
+17302,Xã Tiên Kỳ,423
+17305,Xã Tân An,423
+17308,Xã Nghĩa Dũng,423
+17311,Xã Tân Long,423
+17314,Xã Kỳ Sơn,423
+17317,Xã Hương Sơn,423
+17320,Xã Kỳ Tân,423
+17323,Xã Phú Sơn,423
+17325,Xã Tân Hương,423
+17326,Xã Nghĩa Hành,423
+17329,Thị trấn Anh Sơn,424
+17332,Xã Thọ Sơn,424
+17335,Xã Thành Sơn,424
+17338,Xã Bình Sơn,424
+17341,Xã Tam Sơn,424
+17344,Xã Đỉnh Sơn,424
+17347,Xã Hùng Sơn,424
+17350,Xã Cẩm Sơn,424
+17353,Xã Đức Sơn,424
+17356,Xã Tường Sơn,424
+17357,Xã Hoa Sơn,424
+17359,Xã Tào Sơn,424
+17362,Xã Vĩnh Sơn,424
+17365,Xã Lạng Sơn,424
+17368,Xã Hội Sơn,424
+17371,Xã Thạch Sơn,424
+17374,Xã Phúc Sơn,424
+17377,Xã Long Sơn,424
+17380,Xã Khai Sơn,424
+17383,Xã Lĩnh Sơn,424
+17386,Xã Cao Sơn,424
+17389,Thị trấn Diễn Châu,425
+17392,Xã Diễn Lâm,425
+17395,Xã Diễn Đoài,425
+17398,Xã Diễn Trường,425
+17401,Xã Diễn Yên,425
+17404,Xã Diễn Hoàng,425
+17407,Xã Diễn Hùng,425
+17410,Xã Diễn Mỹ,425
+17413,Xã Diễn Hồng,425
+17416,Xã Diễn Phong,425
+17419,Xã Diễn Hải,425
+17422,Xã Diễn Tháp,425
+17425,Xã Diễn Liên,425
+17428,Xã Diễn Vạn,425
+17431,Xã Diễn Kim,425
+17434,Xã Diễn Kỷ,425
+17437,Xã Diễn Xuân,425
+17440,Xã Diễn Thái,425
+17443,Xã Diễn Đồng,425
+17446,Xã Diễn Bích,425
+17449,Xã Diễn Hạnh,425
+17452,Xã Diễn Ngọc,425
+17455,Xã Diễn Quảng,425
+17458,Xã Diễn Nguyên,425
+17461,Xã Diễn Hoa,425
+17464,Xã Diễn Thành,425
+17467,Xã Diễn Phúc,425
+17476,Xã Diễn Cát,425
+17479,Xã Diễn Thịnh,425
+17482,Xã Diễn Tân,425
+17485,Xã Minh Châu,425
+17488,Xã Diễn Thọ,425
+17491,Xã Diễn Lợi,425
+17494,Xã Diễn Lộc,425
+17497,Xã Diễn Trung,425
+17500,Xã Diễn An,425
+17503,Xã Diễn Phú,425
+17506,Thị trấn Yên Thành,426
+17509,Xã Mã Thành,426
+17510,Xã Tiến Thành,426
+17512,Xã Lăng Thành,426
+17515,Xã Tân Thành,426
+17518,Xã Đức Thành,426
+17521,Xã Kim Thành,426
+17524,Xã Hậu Thành,426
+17525,Xã Hùng Thành,426
+17527,Xã Đô Thành,426
+17530,Xã Thọ Thành,426
+17533,Xã Quang Thành,426
+17536,Xã Tây Thành,426
+17539,Xã Phúc Thành,426
+17542,Xã Hồng Thành,426
+17545,Xã Đồng Thành,426
+17548,Xã Phú Thành,426
+17551,Xã Hoa Thành,426
+17554,Xã Tăng Thành,426
+17557,Xã Văn Thành,426
+17560,Xã Thịnh Thành,426
+17563,Xã Hợp Thành,426
+17566,Xã Xuân Thành,426
+17569,Xã Bắc Thành,426
+17572,Xã Nhân Thành,426
+17575,Xã Trung Thành,426
+17578,Xã Long Thành,426
+17581,Xã Minh Thành,426
+17584,Xã Nam Thành,426
+17587,Xã Vĩnh Thành,426
+17590,Xã Lý Thành,426
+17593,Xã Khánh Thành,426
+17596,Xã Viên Thành,426
+17599,Xã Đại Thành,426
+17602,Xã Liên Thành,426
+17605,Xã Bảo Thành,426
+17608,Xã Mỹ Thành,426
+17611,Xã Công Thành,426
+17614,Xã Sơn Thành,426
+17617,Thị trấn Đô Lương,427
+17619,Xã Giang Sơn Đông,427
+17620,Xã Giang Sơn Tây,427
+17623,Xã Lam Sơn,427
+17626,Xã Bồi Sơn,427
+17629,Xã Hồng Sơn,427
+17632,Xã Bài Sơn,427
+17635,Xã Ngọc Sơn,427
+17638,Xã Bắc Sơn,427
+17641,Xã Tràng Sơn,427
+17644,Xã Thượng Sơn,427
+17647,Xã Hòa Sơn,427
+17650,Xã Đặng Sơn,427
+17653,Xã Đông Sơn,427
+17656,Xã Nam Sơn,427
+17659,Xã Lưu Sơn,427
+17662,Xã Yên Sơn,427
+17665,Xã Văn Sơn,427
+17668,Xã Đà Sơn,427
+17671,Xã Lạc Sơn,427
+17674,Xã Tân Sơn,427
+17677,Xã Thái Sơn,427
+17680,Xã Quang Sơn,427
+17683,Xã Thịnh Sơn,427
+17686,Xã Trung Sơn,427
+17689,Xã Xuân Sơn,427
+17692,Xã Minh Sơn,427
+17695,Xã Thuận Sơn,427
+17698,Xã Nhân Sơn,427
+17701,Xã Hiến Sơn,427
+17704,Xã Mỹ Sơn,427
+17707,Xã Trù Sơn,427
+17710,Xã Đại Sơn,427
+17713,Thị trấn Thanh Chương,428
+17716,Xã Cát Văn,428
+17719,Xã Thanh Nho,428
+17722,Xã Hạnh Lâm,428
+17723,Xã Thanh Sơn,428
+17725,Xã Thanh Hòa,428
+17728,Xã Phong Thịnh,428
+17731,Xã Thanh Phong,428
+17734,Xã Thanh Mỹ,428
+17737,Xã Thanh Tiên,428
+17743,Xã Thanh Liên,428
+17749,Xã Đại Đồng,428
+17752,Xã Thanh Đồng,428
+17755,Xã Thanh Ngọc,428
+17758,Xã Thanh Hương,428
+17759,Xã Ngọc Lâm,428
+17761,Xã Thanh Lĩnh,428
+17764,Xã Đồng Văn,428
+17767,Xã Ngọc Sơn,428
+17770,Xã Thanh Thịnh,428
+17773,Xã Thanh An,428
+17776,Xã Thanh Chi,428
+17779,Xã Xuân Tường,428
+17782,Xã Thanh Dương,428
+17785,Xã Thanh Lương,428
+17788,Xã Thanh Khê,428
+17791,Xã Võ Liệt,428
+17794,Xã Thanh Long,428
+17797,Xã Thanh Thủy,428
+17800,Xã Thanh Khai,428
+17803,Xã Thanh Yên,428
+17806,Xã Thanh Hà,428
+17809,Xã Thanh Giang,428
+17812,Xã Thanh Tùng,428
+17815,Xã Thanh Lâm,428
+17818,Xã Thanh Mai,428
+17821,Xã Thanh Xuân,428
+17824,Xã Thanh Đức,428
+17827,Thị trấn Quán Hành,429
+17830,Xã Nghi Văn,429
+17833,Xã Nghi Yên,429
+17836,Xã Nghi Tiến,429
+17839,Xã Nghi Hưng,429
+17842,Xã Nghi Đồng,429
+17845,Xã Nghi Thiết,429
+17848,Xã Nghi Lâm,429
+17851,Xã Nghi Quang,429
+17854,Xã Nghi Kiều,429
+17857,Xã Nghi Mỹ,429
+17860,Xã Nghi Phương,429
+17863,Xã Nghi Thuận,429
+17866,Xã Nghi Long,429
+17869,Xã Nghi Xá,429
+17875,Xã Nghi Hoa,429
+17878,Xã Khánh Hợp,429
+17881,Xã Nghi Thịnh,429
+17884,Xã Nghi Công Bắc,429
+17887,Xã Nghi Công Nam,429
+17890,Xã Nghi Thạch,429
+17893,Xã Nghi Trung,429
+17896,Xã Nghi Trường,429
+17899,Xã Nghi Diên,429
+17902,Xã Nghi Phong,429
+17905,Xã Nghi Xuân,429
+17911,Xã Nghi Vạn,429
+17917,Xã Phúc Thọ,429
+17926,Xã Nghi Thái,429
+17932,Xã Nam Hưng,430
+17935,Xã Nam Nghĩa,430
+17938,Xã Nam Thanh,430
+17941,Xã Nam Anh,430
+17944,Xã Nam Xuân,430
+17947,Xã Nam Thái,430
+17950,Thị trấn Nam Đàn,430
+17953,Xã Nam Lĩnh,430
+17956,Xã Nam Giang,430
+17959,Xã Xuân Hòa,430
+17962,Xã Hùng Tiến,430
+17968,Xã Thượng Tân Lộc,430
+17971,Xã Kim Liên,430
+17977,Xã Hồng Long,430
+17980,Xã Xuân Lâm,430
+17983,Xã Nam Cát,430
+17986,Xã Khánh Sơn,430
+17989,Xã Trung Phúc Cường,430
+17998,Xã Nam Kim,430
+18001,Thị trấn Hưng Nguyên,431
+18004,Xã Hưng Trung,431
+18007,Xã Hưng Yên,431
+18008,Xã Hưng Yên Bắc,431
+18010,Xã Hưng Tây,431
+18016,Xã Hưng Đạo,431
+18019,Xã Hưng Mỹ,431
+18022,Xã Hưng Thịnh,431
+18025,Xã Hưng Lĩnh,431
+18028,Xã Hưng Thông,431
+18031,Xã Hưng Tân,431
+18034,Xã Hưng Lợi,431
+18037,Xã Hưng Nghĩa,431
+18040,Xã Hưng Phúc,431
+18043,Xã Long Xá,431
+18052,Xã Châu Nhân,431
+18055,Xã Xuân Lam,431
+18064,Xã Hưng Thành,431
+17104,Xã Quỳnh Vinh,432
+17107,Xã Quỳnh Lộc,432
+17110,Phường Quỳnh Thiện,432
+17113,Xã Quỳnh Lập,432
+17116,Xã Quỳnh Trang,432
+17125,Phường Mai Hùng,432
+17128,Phường Quỳnh Dị,432
+17131,Phường Quỳnh Xuân,432
+17134,Phường Quỳnh Phương,432
+17137,Xã Quỳnh Liên,432
+18070,Phường Trần Phú,436
+18073,Phường Nam Hà,436
+18076,Phường Bắc Hà,436
+18077,Phường Nguyễn Du,436
+18079,Phường Tân Giang,436
+18082,Phường Đại Nài,436
+18085,Phường Hà Huy Tập,436
+18088,Xã Thạch Trung,436
+18091,Phường Thạch Quý,436
+18094,Phường Thạch Linh,436
+18097,Phường Văn Yên,436
+18100,Xã Thạch Hạ,436
+18103,Xã Đồng Môn,436
+18109,Xã Thạch Hưng,436
+18112,Xã Thạch Bình,436
+18115,Phường Bắc Hồng,437
+18118,Phường Nam Hồng,437
+18121,Phường Trung Lương,437
+18124,Phường Đức Thuận,437
+18127,Phường Đậu Liêu,437
+18130,Xã Thuận Lộc,437
+18133,Thị trấn Phố Châu,439
+18136,Thị trấn  Tây Sơn,439
+18139,Xã Sơn Hồng,439
+18142,Xã Sơn Tiến,439
+18145,Xã Sơn Lâm,439
+18148,Xã Sơn Lễ,439
+18157,Xã Sơn Giang,439
+18160,Xã Sơn Lĩnh,439
+18163,Xã An Hòa Thịnh,439
+18172,Xã Sơn Tây,439
+18175,Xã Sơn Ninh,439
+18178,Xã Sơn Châu,439
+18181,Xã Tân Mỹ Hà,439
+18184,Xã Quang Diệm,439
+18187,Xã Sơn Trung,439
+18190,Xã Sơn Bằng,439
+18193,Xã Sơn Bình,439
+18196,Xã Sơn Kim 1,439
+18199,Xã Sơn Kim 2,439
+18202,Xã Sơn Trà,439
+18205,Xã Sơn Long,439
+18211,Xã Kim Hoa,439
+18214,Xã Sơn Hàm,439
+18217,Xã Sơn Phú,439
+18223,Xã Sơn Trường,439
+18229,Thị trấn Đức Thọ,440
+18235,Xã Quang Vĩnh,440
+18241,Xã Tùng Châu,440
+18244,Xã Trường Sơn,440
+18247,Xã Liên Minh,440
+18253,Xã Yên Hồ,440
+18259,Xã Tùng Ảnh,440
+18262,Xã Bùi La Nhân,440
+18274,Xã Thanh Bình Thịnh,440
+18277,Xã Lâm Trung Thủy,440
+18280,Xã Hòa Lạc,440
+18283,Xã Tân Dân,440
+18298,Xã An Dũng,440
+18304,Xã Đức Đồng,440
+18307,Xã Đức Lạng,440
+18310,Xã Tân Hương,440
+18313,Thị trấn Vũ Quang,441
+18316,Xã Ân Phú,441
+18319,Xã Đức Giang,441
+18322,Xã Đức Lĩnh,441
+18325,Xã Thọ Điền,441
+18328,Xã Đức Hương,441
+18331,Xã Đức Bồng,441
+18334,Xã Đức Liên,441
+18340,Xã Hương Minh,441
+18343,Xã Quang Thọ,441
+18352,Thị trấn Xuân An,442
+18355,Xã Xuân Hội,442
+18358,Xã Đan Trường,442
+18364,Xã Xuân Phổ,442
+18367,Xã Xuân Hải,442
+18370,Xã Xuân Giang,442
+18373,Thị trấn Tiên Điền,442
+18376,Xã Xuân Yên,442
+18379,Xã Xuân Mỹ,442
+18382,Xã Xuân Thành,442
+18385,Xã Xuân Viên,442
+18388,Xã Xuân Hồng,442
+18391,Xã Cỗ Đạm,442
+18394,Xã Xuân Liên,442
+18397,Xã Xuân Lĩnh,442
+18400,Xã Xuân Lam,442
+18403,Xã Cương Gián,442
+18406,Thị trấn Nghèn,443
+18415,Xã Thiên Lộc,443
+18418,Xã Thuần Thiện,443
+18427,Xã Vượng Lộc,443
+18433,Xã Thanh Lộc,443
+18436,Xã Kim Song Trường,443
+18439,Xã Thường Nga,443
+18445,Xã Tùng Lộc,443
+18454,Xã Phú Lộc,443
+18463,Xã Gia Hanh,443
+18466,Xã Khánh Vĩnh Yên,443
+18472,Xã Trung Lộc,443
+18475,Xã Xuân Lộc,443
+18478,Xã Thượng Lộc,443
+18481,Xã Quang Lộc,443
+18484,Thị trấn Đồng Lộc,443
+18487,Xã Mỹ Lộc,443
+18490,Xã Sơn Lộc,443
+18496,Thị trấn Hương Khê,444
+18499,Xã Điền Mỹ,444
+18502,Xã Hà Linh,444
+18505,Xã Hương Thủy,444
+18508,Xã Hòa Hải,444
+18514,Xã Phúc Đồng,444
+18517,Xã Hương Giang,444
+18520,Xã Lộc Yên,444
+18523,Xã Hương Bình,444
+18526,Xã Hương Long,444
+18529,Xã Phú Gia,444
+18532,Xã Gia Phố,444
+18535,Xã Phú Phong,444
+18538,Xã Hương Đô,444
+18541,Xã Hương Vĩnh,444
+18544,Xã Hương Xuân,444
+18547,Xã Phúc Trạch,444
+18550,Xã Hương Trà,444
+18553,Xã Hương Trạch,444
+18556,Xã Hương Lâm,444
+18559,Xã Hương Liên,444
+18562,Thị trấn Thạch Hà,445
+18565,Xã Ngọc Sơn,445
+18571,Xã Thạch Hải,445
+18586,Xã Thạch Kênh,445
+18589,Xã Thạch Sơn,445
+18592,Xã Thạch Liên,445
+18595,Xã Đỉnh Bàn,445
+18601,Xã Việt Tiến,445
+18604,Xã Thạch Khê,445
+18607,Xã Thạch Long,445
+18619,Xã Thạch Trị,445
+18622,Xã Thạch Lạc,445
+18625,Xã Thạch Ngọc,445
+18628,Xã Tượng Sơn,445
+18631,Xã Thạch Văn,445
+18634,Xã Lưu Vĩnh Sơn,445
+18637,Xã Thạch Thắng,445
+18643,Xã Thạch Đài,445
+18649,Xã Thạch Hội,445
+18652,Xã Tân Lâm Hương,445
+18658,Xã Thạch Xuân,445
+18667,Xã Nam Điền,445
+18673,Thị trấn Cẩm Xuyên,446
+18676,Thị trấn Thiên Cầm,446
+18679,Xã Yên Hòa,446
+18682,Xã Cẩm Dương,446
+18685,Xã Cẩm Bình,446
+18691,Xã Cẩm Vĩnh,446
+18694,Xã Cẩm Thành,446
+18697,Xã Cẩm Quang,446
+18706,Xã Cẩm Thạch,446
+18709,Xã Cẩm Nhượng,446
+18712,Xã Nam Phúc Thăng,446
+18715,Xã Cẩm Duệ,446
+18721,Xã Cẩm Lĩnh,446
+18724,Xã Cẩm Quan,446
+18727,Xã Cẩm Hà,446
+18730,Xã Cẩm Lộc,446
+18733,Xã Cẩm Hưng,446
+18736,Xã Cẩm Thịnh,446
+18739,Xã Cẩm Mỹ,446
+18742,Xã Cẩm Trung,446
+18745,Xã Cẩm Sơn,446
+18748,Xã Cẩm Lạc,446
+18751,Xã Cẩm Minh,446
+18757,Xã Kỳ Xuân,447
+18760,Xã Kỳ Bắc,447
+18763,Xã Kỳ Phú,447
+18766,Xã Kỳ Phong,447
+18769,Xã Kỳ Tiến,447
+18772,Xã Kỳ Giang,447
+18775,Xã Kỳ Đồng,447
+18778,Xã Kỳ Khang,447
+18784,Xã Kỳ Văn,447
+18787,Xã Kỳ Trung,447
+18790,Xã Kỳ Thọ,447
+18793,Xã Kỳ Tây,447
+18799,Xã Kỳ Thượng,447
+18802,Xã Kỳ Hải,447
+18805,Xã Kỳ Thư,447
+18811,Xã Kỳ Châu,447
+18814,Xã Kỳ Tân,447
+18838,Xã Lâm Hợp,447
+18844,Xã Kỳ Sơn,447
+18850,Xã Kỳ Lạc,447
+18409,Xã Tân Lộc,448
+18412,Xã Hồng Lộc,448
+18421,Xã Thịnh Lộc,448
+18430,Xã Bình An,448
+18457,Xã Ích Hậu,448
+18493,Xã Phù Lưu,448
+18568,Thị trấn Lộc Hà,448
+18577,Xã Thạch Mỹ,448
+18580,Xã Thạch Kim,448
+18583,Xã Thạch Châu,448
+18598,Xã Hộ Độ,448
+18670,Xã Mai Phụ,448
+18754,Phường Hưng Trí,449
+18781,Xã Kỳ Ninh,449
+18796,Xã Kỳ Lợi,449
+18808,Xã Kỳ Hà,449
+18820,Phường Kỳ Trinh,449
+18823,Phường Kỳ Thịnh,449
+18829,Xã Kỳ Hoa,449
+18832,Phường Kỳ Phương,449
+18835,Phường Kỳ Long,449
+18841,Phường Kỳ Liên,449
+18847,Xã Kỳ Nam,449
+18853,Phường Hải Thành,450
+18856,Phường Đồng Phú,450
+18859,Phường Bắc Lý,450
+18865,Phường Nam Lý,450
+18868,Phường Đồng Hải,450
+18871,Phường Đồng Sơn,450
+18874,Phường Phú Hải,450
+18877,Phường Bắc Nghĩa,450
+18880,Phường Đức Ninh Đông,450
+18883,Xã Quang Phú,450
+18886,Xã Lộc Ninh,450
+18889,Xã Bảo Ninh,450
+18892,Xã Nghĩa Ninh,450
+18895,Xã Thuận Đức,450
+18898,Xã Đức Ninh,450
+18901,Thị trấn Quy Đạt,452
+18904,Xã Dân Hóa,452
+18907,Xã Trọng Hóa,452
+18910,Xã Hóa Phúc,452
+18913,Xã Hồng Hóa,452
+18916,Xã Hóa Thanh,452
+18919,Xã Hóa Tiến,452
+18922,Xã Hóa Hợp,452
+18925,Xã Xuân Hóa,452
+18928,Xã Yên Hóa,452
+18931,Xã Minh Hóa,452
+18934,Xã Tân Hóa,452
+18937,Xã Hóa Sơn,452
+18943,Xã Trung Hóa,452
+18946,Xã Thượng Hóa,452
+18949,Thị trấn Đồng Lê,453
+18952,Xã Hương Hóa,453
+18955,Xã Kim Hóa,453
+18958,Xã Thanh Hóa,453
+18961,Xã Thanh Thạch,453
+18964,Xã Thuận Hóa,453
+18967,Xã Lâm Hóa,453
+18970,Xã Lê Hóa,453
+18973,Xã Sơn Hóa,453
+18976,Xã Đồng Hóa,453
+18979,Xã Ngư Hóa,453
+18985,Xã Thạch Hóa,453
+18988,Xã Đức Hóa,453
+18991,Xã Phong Hóa,453
+18994,Xã Mai Hóa,453
+18997,Xã Tiến Hóa,453
+19000,Xã Châu Hóa,453
+19003,Xã Cao Quảng,453
+19006,Xã Văn Hóa,453
+19012,Xã Quảng Hợp,454
+19015,Xã Quảng Kim,454
+19018,Xã Quảng Đông,454
+19021,Xã Quảng Phú,454
+19024,Xã Quảng Châu,454
+19027,Xã Quảng Thạch,454
+19030,Xã Quảng Lưu,454
+19033,Xã Quảng Tùng,454
+19036,Xã Cảnh Dương,454
+19039,Xã Quảng Tiến,454
+19042,Xã Quảng Hưng,454
+19045,Xã Quảng Xuân,454
+19048,Xã Cảnh Hóa,454
+19051,Xã Liên Trường,454
+19057,Xã Quảng Phương,454
+19063,Xã Phù Hóa,454
+19072,Xã Quảng Thanh,454
+19111,Thị trấn Hoàn Lão,455
+19114,Thị trấn NT Việt Trung,455
+19117,Xã Xuân Trạch,455
+19120,Xã Mỹ Trạch,455
+19123,Xã Hạ Trạch,455
+19126,Xã Bắc Trạch,455
+19129,Xã Lâm Trạch,455
+19132,Xã Thanh Trạch,455
+19135,Xã Liên Trạch,455
+19138,Xã Phúc Trạch,455
+19141,Xã Cự Nẫm,455
+19144,Xã Hải Phú,455
+19147,Xã Thượng Trạch,455
+19150,Xã Sơn Lộc,455
+19156,Xã Hưng Trạch,455
+19159,Xã Đồng Trạch,455
+19162,Xã Đức Trạch,455
+19165,Thị trấn Phong Nha,455
+19168,Xã Vạn Trạch,455
+19174,Xã Phú Định,455
+19177,Xã Trung Trạch,455
+19180,Xã Tây Trạch,455
+19183,Xã Hòa Trạch,455
+19186,Xã Đại Trạch,455
+19189,Xã Nhân Trạch,455
+19192,Xã Tân Trạch,455
+19195,Xã Nam Trạch,455
+19198,Xã Lý Trạch,455
+19201,Thị trấn Quán Hàu,456
+19204,Xã Trường Sơn,456
+19207,Xã Lương Ninh,456
+19210,Xã Vĩnh Ninh,456
+19213,Xã Võ Ninh,456
+19216,Xã Hải Ninh,456
+19219,Xã Hàm Ninh,456
+19222,Xã Duy Ninh,456
+19225,Xã Gia Ninh,456
+19228,Xã Trường Xuân,456
+19231,Xã Hiền Ninh,456
+19234,Xã Tân Ninh,456
+19237,Xã Xuân Ninh,456
+19240,Xã An Ninh,456
+19243,Xã Vạn Ninh,456
+19246,Thị trấn NT Lệ Ninh,457
+19249,Thị trấn Kiến Giang,457
+19252,Xã Hồng Thủy,457
+19255,Xã Ngư Thủy Bắc,457
+19258,Xã Hoa Thủy,457
+19261,Xã Thanh Thủy,457
+19264,Xã An Thủy,457
+19267,Xã Phong Thủy,457
+19270,Xã Cam Thủy,457
+19273,Xã Ngân Thủy,457
+19276,Xã Sơn Thủy,457
+19279,Xã Lộc Thủy,457
+19285,Xã Liên Thủy,457
+19288,Xã Hưng Thủy,457
+19291,Xã Dương Thủy,457
+19294,Xã Tân Thủy,457
+19297,Xã Phú Thủy,457
+19300,Xã Xuân Thủy,457
+19303,Xã Mỹ Thủy,457
+19306,Xã Ngư Thủy ,457
+19309,Xã Mai Thủy,457
+19312,Xã Sen Thủy,457
+19315,Xã Thái Thủy,457
+19318,Xã Kim Thủy,457
+19321,Xã Trường Thủy,457
+19327,Xã Lâm Thủy,457
+19009,Phường Ba Đồn,458
+19060,Phường Quảng Long,458
+19066,Phường Quảng Thọ,458
+19069,Xã Quảng Tiên,458
+19075,Xã Quảng Trung,458
+19078,Phường Quảng Phong,458
+19081,Phường Quảng Thuận,458
+19084,Xã Quảng Tân,458
+19087,Xã Quảng Hải,458
+19090,Xã Quảng Sơn,458
+19093,Xã Quảng Lộc,458
+19096,Xã Quảng Thủy,458
+19099,Xã Quảng Văn,458
+19102,Phường Quảng Phúc,458
+19105,Xã Quảng Hòa,458
+19108,Xã Quảng Minh,458
+19330,Phường Đông Giang,461
+19333,Phường 1,461
+19336,Phường Đông Lễ,461
+19339,Phường Đông Thanh,461
+19342,Phường 2,461
+19345,Phường 4,461
+19348,Phường 5,461
+19351,Phường Đông Lương,461
+19354,Phường 3,461
+19357,Phường 1,462
+19358,Phường An Đôn,462
+19360,Phường 2,462
+19361,Phường 3,462
+19705,Xã Hải Lệ,462
+19363,Thị trấn Hồ Xá,464
+19366,Thị trấn Bến Quan,464
+19369,Xã Vĩnh Thái,464
+19372,Xã Vĩnh Tú,464
+19375,Xã Vĩnh Chấp,464
+19378,Xã Trung Nam,464
+19384,Xã Kim Thạch,464
+19387,Xã Vĩnh Long,464
+19393,Xã Vĩnh Khê,464
+19396,Xã Vĩnh Hòa,464
+19402,Xã Vĩnh Thủy,464
+19405,Xã Vĩnh Lâm,464
+19408,Xã Hiền Thành,464
+19414,Thị trấn Cửa Tùng,464
+19417,Xã Vĩnh Hà,464
+19420,Xã Vĩnh Sơn,464
+19423,Xã Vĩnh Giang,464
+19426,Xã Vĩnh Ô,464
+19429,Thị trấn Khe Sanh,465
+19432,Thị trấn Lao Bảo,465
+19435,Xã Hướng Lập,465
+19438,Xã Hướng Việt,465
+19441,Xã Hướng Phùng,465
+19444,Xã Hướng Sơn,465
+19447,Xã Hướng Linh,465
+19450,Xã Tân Hợp,465
+19453,Xã Hướng Tân,465
+19456,Xã Tân Thành,465
+19459,Xã Tân Long,465
+19462,Xã Tân Lập,465
+19465,Xã Tân Liên,465
+19468,Xã Húc,465
+19471,Xã Thuận,465
+19474,Xã Hướng Lộc,465
+19477,Xã Ba Tầng,465
+19480,Xã Thanh,465
+19483,Xã  A Dơi,465
+19489,Xã Lìa,465
+19492,Xã Xy,465
+19495,Thị trấn Gio Linh,466
+19496,Thị trấn Cửa Việt,466
+19498,Xã Trung Giang,466
+19501,Xã Trung Hải,466
+19504,Xã Trung Sơn,466
+19507,Xã Phong Bình,466
+19510,Xã Gio Mỹ,466
+19519,Xã Gio Hải,466
+19522,Xã Gio An,466
+19525,Xã Gio Châu,466
+19531,Xã Gio Việt,466
+19534,Xã Linh Trường,466
+19537,Xã Gio Sơn,466
+19543,Xã Gio Mai,466
+19546,Xã Hải Thái,466
+19549,Xã Linh Hải,466
+19552,Xã Gio Quang,466
+19555,Thị trấn Krông Klang,467
+19558,Xã Mò Ó,467
+19561,Xã Hướng Hiệp,467
+19564,Xã Đa Krông,467
+19567,Xã Triệu Nguyên,467
+19570,Xã Ba Lòng,467
+19576,Xã Ba Nang,467
+19579,Xã Tà Long,467
+19582,Xã Húc Nghì,467
+19585,Xã A Vao,467
+19588,Xã Tà Rụt,467
+19591,Xã A Bung,467
+19594,Xã A Ngo,467
+19597,Thị trấn Cam Lộ,468
+19600,Xã Cam Tuyền,468
+19603,Xã Thanh An,468
+19606,Xã Cam Thủy,468
+19612,Xã Cam Thành,468
+19615,Xã Cam Hiếu,468
+19618,Xã Cam Chính,468
+19621,Xã Cam Nghĩa,468
+19624,Thị Trấn Ái Tử,469
+19627,Xã Triệu An,469
+19630,Xã Triệu Vân,469
+19633,Xã Triệu Phước,469
+19636,Xã Triệu Độ,469
+19639,Xã Triệu Trạch,469
+19642,Xã Triệu Thuận,469
+19645,Xã Triệu Đại,469
+19648,Xã Triệu Hòa,469
+19651,Xã Triệu Lăng,469
+19654,Xã Triệu Sơn,469
+19657,Xã Triệu Long,469
+19660,Xã Triệu Tài,469
+19666,Xã Triệu Trung,469
+19669,Xã Triệu Ái,469
+19672,Xã Triệu Thượng,469
+19675,Xã Triệu Giang,469
+19678,Xã Triệu Thành,469
+19681,Thị trấn Diên Sanh,470
+19684,Xã Hải An,470
+19687,Xã Hải Ba,470
+19693,Xã Hải Quy,470
+19696,Xã Hải Quế,470
+19699,Xã Hải Hưng,470
+19702,Xã Hải Phú,470
+19708,Xã Hải Thượng,470
+19711,Xã Hải Dương,470
+19714,Xã Hải Định,470
+19717,Xã Hải Lâm,470
+19726,Xã Hải Phong,470
+19729,Xã Hải Trường,470
+19735,Xã Hải Sơn,470
+19738,Xã Hải Chánh,470
+19741,Xã Hải Khê,470
+19750,Phường Tây Lộc,474
+19753,Phường Thuận Lộc,474
+19756,Phường Gia Hội,474
+19759,Phường Phú Hậu,474
+19762,Phường Thuận Hòa,474
+19768,Phường Đông Ba,474
+19774,Phường Kim Long,474
+19777,Phường Vỹ Dạ,474
+19780,Phường Phường Đúc,474
+19783,Phường Vĩnh Ninh,474
+19786,Phường Phú Hội,474
+19789,Phường Phú Nhuận,474
+19792,Phường Xuân Phú,474
+19795,Phường Trường An,474
+19798,Phường Phước Vĩnh,474
+19801,Phường An Cựu,474
+19803,Phường An Hòa,474
+19804,Phường Hương Sơ,474
+19807,Phường Thuỷ Biều,474
+19810,Phường Hương Long,474
+19813,Phường Thuỷ Xuân,474
+19815,Phường An Đông,474
+19816,Phường An Tây,474
+19900,Phường Thuận An,474
+19906,Xã Phú Dương,474
+19909,Xã Phú Mậu,474
+19924,Xã Phú Thanh,474
+19930,Phường Phú Thượng,474
+19963,Phường Thủy Vân,474
+19981,Xã Thủy Bằng,474
+19999,Xã Hải Dương,474
+20002,Xã Hương Phong,474
+20014,Phường Hương Vinh,474
+20023,Phường Hương An,474
+20029,Phường Hương Hồ,474
+20032,Xã Hương Thọ,474
+19819,Thị trấn Phong Điền,476
+19822,Xã Điền Hương,476
+19825,Xã Điền Môn,476
+19828,Xã Điền Lộc,476
+19831,Xã Phong Bình,476
+19834,Xã Điền Hòa,476
+19837,Xã Phong Chương,476
+19840,Xã Phong Hải,476
+19843,Xã Điền Hải,476
+19846,Xã Phong Hòa,476
+19849,Xã Phong Thu,476
+19852,Xã Phong Hiền,476
+19855,Xã Phong Mỹ,476
+19858,Xã Phong An,476
+19861,Xã Phong Xuân,476
+19864,Xã Phong Sơn,476
+19867,Thị trấn Sịa,477
+19870,Xã Quảng Thái,477
+19873,Xã Quảng Ngạn,477
+19876,Xã Quảng Lợi,477
+19879,Xã Quảng Công,477
+19882,Xã Quảng Phước,477
+19885,Xã Quảng Vinh,477
+19888,Xã Quảng An,477
+19891,Xã Quảng Thành,477
+19894,Xã Quảng Thọ,477
+19897,Xã Quảng Phú,477
+19903,Xã Phú Thuận,478
+19912,Xã Phú An,478
+19915,Xã Phú Hải,478
+19918,Xã Phú Xuân,478
+19921,Xã Phú Diên,478
+19927,Xã Phú Mỹ,478
+19933,Xã Phú Hồ,478
+19936,Xã Vinh Xuân,478
+19939,Xã Phú Lương,478
+19942,Thị trấn Phú Đa,478
+19945,Xã Vinh Thanh,478
+19948,Xã Vinh An,478
+19954,Xã Phú Gia,478
+19957,Xã Vinh Hà,478
+19960,Phường Phú Bài,479
+19966,Xã Thủy Thanh,479
+19969,Phường Thủy Dương,479
+19972,Phường Thủy Phương,479
+19975,Phường Thủy Châu,479
+19978,Phường Thủy Lương,479
+19984,Xã Thủy Tân,479
+19987,Xã Thủy Phù,479
+19990,Xã Phú Sơn,479
+19993,Xã Dương Hòa,479
+19996,Phường Tứ Hạ,480
+20005,Xã Hương Toàn,480
+20008,Phường Hương Vân,480
+20011,Phường Hương Văn,480
+20017,Phường Hương Xuân,480
+20020,Phường Hương Chữ,480
+20026,Xã Hương Bình,480
+20035,Xã Bình Tiến,480
+20041,Xã Bình Thành,480
+20044,Thị trấn A Lưới,481
+20047,Xã Hồng Vân,481
+20050,Xã Hồng Hạ,481
+20053,Xã Hồng Kim,481
+20056,Xã Trung Sơn,481
+20059,Xã Hương Nguyên,481
+20065,Xã Hồng Bắc,481
+20068,Xã A Ngo,481
+20071,Xã Sơn Thủy,481
+20074,Xã Phú Vinh,481
+20080,Xã Hương Phong,481
+20083,Xã Quảng Nhâm,481
+20086,Xã Hồng Thượng,481
+20089,Xã Hồng Thái,481
+20095,Xã A Roàng,481
+20098,Xã Đông Sơn,481
+20101,Xã Lâm Đớt,481
+20104,Xã Hồng Thủy,481
+20107,Thị trấn Phú Lộc,482
+20110,Thị trấn Lăng Cô,482
+20113,Xã Vinh Mỹ,482
+20116,Xã Vinh Hưng,482
+20122,Xã Giang Hải,482
+20125,Xã Vinh Hiền,482
+20128,Xã Lộc Bổn,482
+20131,Xã Lộc Sơn,482
+20134,Xã Lộc Bình,482
+20137,Xã Lộc Vĩnh,482
+20140,Xã Lộc An,482
+20143,Xã Lộc Điền,482
+20146,Xã Lộc Thủy,482
+20149,Xã Lộc Trì,482
+20152,Xã Lộc Tiến,482
+20155,Xã Lộc Hòa,482
+20158,Xã Xuân Lộc,482
+20161,Thị trấn Khe Tre,483
+20164,Xã Hương Phú,483
+20167,Xã Hương Sơn,483
+20170,Xã Hương Lộc,483
+20173,Xã Thượng Quảng,483
+20179,Xã Hương Xuân,483
+20182,Xã Hương Hữu,483
+20185,Xã Thượng Lộ,483
+20188,Xã Thượng Long,483
+20191,Xã Thượng Nhật,483
+20194,Phường Hòa Hiệp Bắc,490
+20195,Phường Hòa Hiệp Nam,490
+20197,Phường Hòa Khánh Bắc,490
+20198,Phường Hòa Khánh Nam,490
+20200,Phường Hòa Minh,490
+20203,Phường Tam Thuận,491
+20206,Phường Thanh Khê Tây,491
+20207,Phường Thanh Khê Đông,491
+20209,Phường Xuân Hà,491
+20212,Phường Tân Chính,491
+20215,Phường Chính Gián,491
+20218,Phường Vĩnh Trung,491
+20221,Phường Thạc Gián,491
+20224,Phường An Khê,491
+20225,Phường Hòa Khê,491
+20227,Phường Thanh Bình,492
+20230,Phường Thuận Phước,492
+20233,Phường Thạch Thang,492
+20236,Phường Hải Châu  I,492
+20239,Phường Hải Châu II,492
+20242,Phường Phước Ninh,492
+20245,Phường Hòa Thuận Tây,492
+20246,Phường Hòa Thuận Đông,492
+20248,Phường Nam Dương,492
+20251,Phường Bình Hiên,492
+20254,Phường Bình Thuận,492
+20257,Phường Hòa Cường Bắc,492
+20258,Phường Hòa Cường Nam,492
+20263,Phường Thọ Quang,493
+20266,Phường Nại Hiên Đông,493
+20269,Phường Mân Thái,493
+20272,Phường An Hải Bắc,493
+20275,Phường Phước Mỹ,493
+20278,Phường An Hải Tây,493
+20281,Phường An Hải Đông,493
+20284,Phường Mỹ An,494
+20285,Phường Khuê Mỹ,494
+20287,Phường Hoà Quý,494
+20290,Phường Hoà Hải,494
+20260,Phường Khuê Trung,495
+20305,Phường Hòa Phát,495
+20306,Phường Hòa An,495
+20311,Phường Hòa Thọ Tây,495
+20312,Phường Hòa Thọ Đông,495
+20314,Phường Hòa Xuân,495
+20293,Xã Hòa Bắc,497
+20296,Xã Hòa Liên,497
+20299,Xã Hòa Ninh,497
+20302,Xã Hòa Sơn,497
+20308,Xã Hòa Nhơn,497
+20317,Xã Hòa Phú,497
+20320,Xã Hòa Phong,497
+20323,Xã Hòa Châu,497
+20326,Xã Hòa Tiến,497
+20329,Xã Hòa Phước,497
+20332,Xã Hòa Khương,497
+20335,Phường Tân Thạnh,502
+20338,Phường Phước Hòa,502
+20341,Phường An Mỹ,502
+20344,Phường Hòa Hương,502
+20347,Phường An Xuân,502
+20350,Phường An Sơn,502
+20353,Phường Trường Xuân,502
+20356,Phường An Phú,502
+20359,Xã Tam Thanh,502
+20362,Xã Tam Thăng,502
+20371,Xã Tam Phú,502
+20375,Phường Hoà Thuận,502
+20389,Xã Tam Ngọc,502
+20398,Phường Minh An,503
+20401,Phường Tân An,503
+20404,Phường Cẩm Phô,503
+20407,Phường Thanh Hà,503
+20410,Phường Sơn Phong,503
+20413,Phường Cẩm Châu,503
+20416,Phường Cửa Đại,503
+20419,Phường Cẩm An,503
+20422,Xã Cẩm Hà,503
+20425,Xã Cẩm Kim,503
+20428,Phường Cẩm Nam,503
+20431,Xã Cẩm Thanh,503
+20434,Xã Tân Hiệp,503
+20437,Xã Ch'ơm,504
+20440,Xã Ga Ri,504
+20443,Xã A Xan,504
+20446,Xã Tr'Hy,504
+20449,Xã Lăng,504
+20452,Xã A Nông,504
+20455,Xã A Tiêng,504
+20458,Xã Bha Lê,504
+20461,Xã A Vương,504
+20464,Xã Dang,504
+20467,Thị trấn P Rao,505
+20470,Xã Tà Lu,505
+20473,Xã Sông Kôn,505
+20476,Xã Jơ Ngây,505
+20479,Xã A Ting,505
+20482,Xã  Tư,505
+20485,Xã Ba,505
+20488,Xã A Rooi,505
+20491,Xã Za Hung,505
+20494,Xã Mà Cooi,505
+20497,Xã Ka Dăng,505
+20500,Thị Trấn Ái Nghĩa,506
+20503,Xã Đại Sơn,506
+20506,Xã Đại Lãnh,506
+20509,Xã Đại Hưng,506
+20512,Xã Đại Hồng,506
+20515,Xã Đại Đồng,506
+20518,Xã Đại Quang,506
+20521,Xã Đại Nghĩa,506
+20524,Xã Đại Hiệp,506
+20527,Xã Đại Thạnh,506
+20530,Xã Đại Chánh,506
+20533,Xã Đại Tân,506
+20536,Xã Đại Phong,506
+20539,Xã Đại Minh,506
+20542,Xã Đại Thắng,506
+20545,Xã Đại Cường,506
+20547,Xã Đại An,506
+20548,Xã Đại Hòa,506
+20551,Phường Vĩnh Điện,507
+20554,Xã Điện Tiến,507
+20557,Xã Điện Hòa,507
+20560,Xã Điện Thắng Bắc,507
+20561,Xã Điện Thắng Trung,507
+20562,Xã Điện Thắng Nam,507
+20563,Phường Điện Ngọc,507
+20566,Xã Điện Hồng,507
+20569,Xã Điện Thọ,507
+20572,Xã Điện Phước,507
+20575,Phường Điện An,507
+20578,Phường Điện Nam Bắc,507
+20579,Phường Điện Nam Trung,507
+20580,Phường Điện Nam Đông,507
+20581,Phường Điện Dương,507
+20584,Xã Điện Quang,507
+20587,Xã Điện Trung,507
+20590,Xã Điện Phong,507
+20593,Xã Điện Minh,507
+20596,Xã Điện Phương,507
+20599,Thị trấn Nam Phước,508
+20602,Xã Duy Thu,508
+20605,Xã Duy Phú,508
+20608,Xã Duy Tân,508
+20611,Xã Duy Hòa,508
+20614,Xã Duy Châu,508
+20617,Xã Duy Trinh,508
+20620,Xã Duy Sơn,508
+20623,Xã Duy Trung,508
+20626,Xã Duy Phước,508
+20629,Xã Duy Thành,508
+20632,Xã Duy Vinh,508
+20635,Xã Duy Nghĩa,508
+20638,Xã Duy Hải,508
+20641,Thị trấn Đông Phú,509
+20644,Xã Quế Xuân 1,509
+20647,Xã Quế Xuân 2,509
+20650,Xã Quế Phú,509
+20651,Thị trấn Hương An,509
+20659,Xã Quế Hiệp,509
+20662,Xã Quế Thuận,509
+20665,Xã Quế Mỹ,509
+20677,Xã Quế Long,509
+20680,Xã Quế Châu,509
+20683,Xã Quế Phong,509
+20686,Xã Quế An,509
+20689,Xã Quế Minh,509
+20695,Thị trấn Thạnh Mỹ,510
+20698,Xã Laêê,510
+20699,Xã Chơ Chun,510
+20701,Xã Zuôich,510
+20702,Xã Tà Pơơ,510
+20704,Xã La Dêê,510
+20705,Xã Đắc Tôi,510
+20707,Xã Chà Vàl,510
+20710,Xã Tà Bhinh,510
+20713,Xã Cà Dy,510
+20716,Xã Đắc Pre,510
+20719,Xã Đắc Pring,510
+20722,Thị trấn Khâm Đức,511
+20725,Xã Phước Xuân,511
+20728,Xã Phước Hiệp,511
+20729,Xã Phước Hoà,511
+20731,Xã Phước Đức,511
+20734,Xã Phước Năng,511
+20737,Xã Phước Mỹ,511
+20740,Xã Phước Chánh,511
+20743,Xã Phước Công,511
+20746,Xã Phước Kim,511
+20749,Xã Phước Lộc,511
+20752,Xã Phước Thành,511
+20758,Xã Hiệp Hòa,512
+20761,Xã Hiệp Thuận,512
+20764,Xã Quế Thọ,512
+20767,Xã Bình Lâm,512
+20770,Xã Sông Trà,512
+20773,Xã Phước Trà,512
+20776,Xã Phước Gia,512
+20779,Thị trấn Tân Bình,512
+20782,Xã Quế Lưu,512
+20785,Xã Thăng Phước,512
+20788,Xã Bình Sơn,512
+20791,Thị trấn Hà Lam,513
+20794,Xã Bình Dương,513
+20797,Xã Bình Giang,513
+20800,Xã Bình Nguyên,513
+20803,Xã Bình Phục,513
+20806,Xã Bình Triều,513
+20809,Xã Bình Đào,513
+20812,Xã Bình Minh,513
+20815,Xã Bình Lãnh,513
+20818,Xã Bình Trị,513
+20821,Xã Bình Định Bắc,513
+20822,Xã Bình Định Nam,513
+20824,Xã Bình Quý,513
+20827,Xã Bình Phú,513
+20830,Xã Bình Chánh,513
+20833,Xã Bình Tú,513
+20836,Xã Bình Sa,513
+20839,Xã Bình Hải,513
+20842,Xã Bình Quế,513
+20845,Xã Bình An,513
+20848,Xã Bình Trung,513
+20851,Xã Bình Nam,513
+20854,Thị trấn Tiên Kỳ,514
+20857,Xã Tiên Sơn,514
+20860,Xã Tiên Hà,514
+20863,Xã Tiên Cẩm,514
+20866,Xã Tiên Châu,514
+20869,Xã Tiên Lãnh,514
+20872,Xã Tiên Ngọc,514
+20875,Xã Tiên Hiệp,514
+20878,Xã Tiên Cảnh,514
+20881,Xã Tiên Mỹ,514
+20884,Xã Tiên Phong,514
+20887,Xã Tiên Thọ,514
+20890,Xã Tiên An,514
+20893,Xã Tiên Lộc,514
+20896,Xã Tiên Lập,514
+20899,Thị trấn Trà My,515
+20900,Xã Trà Sơn,515
+20902,Xã Trà Kót,515
+20905,Xã Trà Nú,515
+20908,Xã Trà Đông,515
+20911,Xã Trà Dương,515
+20914,Xã Trà Giang,515
+20917,Xã Trà Bui,515
+20920,Xã Trà Đốc,515
+20923,Xã Trà Tân,515
+20926,Xã Trà Giác,515
+20929,Xã Trà Giáp,515
+20932,Xã Trà Ka,515
+20935,Xã Trà Leng,516
+20938,Xã Trà Dơn,516
+20941,Xã Trà Tập,516
+20944,Xã Trà Mai,516
+20947,Xã Trà Cang,516
+20950,Xã Trà Linh,516
+20953,Xã Trà Nam,516
+20956,Xã Trà Don,516
+20959,Xã Trà Vân,516
+20962,Xã Trà Vinh,516
+20965,Thị trấn Núi Thành,517
+20968,Xã Tam Xuân I,517
+20971,Xã Tam Xuân II,517
+20974,Xã Tam Tiến,517
+20977,Xã Tam Sơn,517
+20980,Xã Tam Thạnh,517
+20983,Xã Tam Anh Bắc,517
+20984,Xã Tam Anh Nam,517
+20986,Xã Tam Hòa,517
+20989,Xã Tam Hiệp,517
+20992,Xã Tam Hải,517
+20995,Xã Tam Giang,517
+20998,Xã Tam Quang,517
+21001,Xã Tam Nghĩa,517
+21004,Xã Tam Mỹ Tây,517
+21005,Xã Tam Mỹ Đông,517
+21007,Xã Tam Trà,517
+20364,Thị trấn Phú Thịnh,518
+20365,Xã Tam Thành,518
+20368,Xã Tam An,518
+20374,Xã Tam Đàn,518
+20377,Xã Tam Lộc,518
+20380,Xã Tam Phước,518
+20383,Xã Tam Vinh,518
+20386,Xã Tam Thái,518
+20387,Xã Tam Đại,518
+20392,Xã Tam Dân,518
+20395,Xã Tam Lãnh,518
+20656,Xã Quế Trung,519
+20668,Xã Ninh Phước,519
+20669,Xã Phước Ninh,519
+20671,Xã Quế Lộc,519
+20672,Xã Sơn Viên,519
+20692,Xã Quế Lâm,519
+21010,Phường Lê Hồng Phong,522
+21013,Phường Trần Phú,522
+21016,Phường Quảng Phú,522
+21019,Phường Nghĩa Chánh,522
+21022,Phường Trần Hưng Đạo,522
+21025,Phường Nguyễn Nghiêm,522
+21028,Phường Nghĩa Lộ,522
+21031,Phường Chánh Lộ,522
+21034,Xã Nghĩa Dũng,522
+21037,Xã Nghĩa Dõng,522
+21172,Phường Trương Quang Trọng,522
+21187,Xã Tịnh Hòa,522
+21190,Xã Tịnh Kỳ,522
+21199,Xã Tịnh Thiện,522
+21202,Xã Tịnh Ấn Đông,522
+21208,Xã Tịnh Châu,522
+21211,Xã Tịnh Khê,522
+21214,Xã Tịnh Long,522
+21223,Xã Tịnh Ấn Tây,522
+21232,Xã Tịnh An,522
+21253,Xã Nghĩa Phú,522
+21256,Xã Nghĩa Hà,522
+21262,Xã Nghĩa An,522
+21040,Thị Trấn Châu Ổ,524
+21043,Xã Bình Thuận,524
+21046,Xã Bình Thạnh,524
+21049,Xã Bình Đông,524
+21052,Xã Bình Chánh,524
+21055,Xã Bình Nguyên,524
+21058,Xã Bình Khương,524
+21061,Xã Bình Trị,524
+21064,Xã Bình An,524
+21067,Xã Bình Hải,524
+21070,Xã Bình Dương,524
+21073,Xã Bình Phước,524
+21079,Xã Bình Hòa,524
+21082,Xã Bình Trung,524
+21085,Xã Bình Minh,524
+21088,Xã Bình Long,524
+21091,Xã Bình Thanh ,524
+21100,Xã Bình Chương,524
+21103,Xã Bình Hiệp,524
+21106,Xã Bình Mỹ,524
+21109,Xã Bình Tân Phú,524
+21112,Xã Bình Châu,524
+21115,Thị trấn Trà Xuân,525
+21118,Xã Trà Giang,525
+21121,Xã Trà Thủy,525
+21124,Xã Trà Hiệp,525
+21127,Xã Trà Bình,525
+21130,Xã Trà Phú,525
+21133,Xã Trà Lâm,525
+21136,Xã Trà Tân,525
+21139,Xã Trà Sơn,525
+21142,Xã Trà Bùi,525
+21145,Xã Trà Thanh,525
+21148,Xã Sơn Trà,525
+21154,Xã Trà Phong,525
+21157,Xã Hương Trà,525
+21163,Xã Trà Xinh,525
+21166,Xã Trà Tây,525
+21175,Xã Tịnh Thọ,527
+21178,Xã Tịnh Trà,527
+21181,Xã Tịnh Phong,527
+21184,Xã Tịnh Hiệp,527
+21193,Xã Tịnh Bình,527
+21196,Xã Tịnh Đông,527
+21205,Xã Tịnh Bắc,527
+21217,Xã Tịnh Sơn,527
+21220,Xã Tịnh Hà,527
+21226,Xã Tịnh Giang,527
+21229,Xã Tịnh Minh,527
+21235,Thị trấn La Hà,528
+21238,Thị trấn Sông Vệ,528
+21241,Xã Nghĩa Lâm,528
+21244,Xã Nghĩa Thắng,528
+21247,Xã Nghĩa Thuận,528
+21250,Xã Nghĩa Kỳ,528
+21259,Xã Nghĩa Sơn,528
+21268,Xã Nghĩa Hòa,528
+21271,Xã Nghĩa Điền,528
+21274,Xã Nghĩa Thương,528
+21277,Xã Nghĩa Trung,528
+21280,Xã Nghĩa Hiệp,528
+21283,Xã Nghĩa Phương,528
+21286,Xã Nghĩa Mỹ,528
+21289,Thị trấn Di Lăng,529
+21292,Xã Sơn Hạ,529
+21295,Xã Sơn Thành,529
+21298,Xã Sơn Nham,529
+21301,Xã Sơn Bao,529
+21304,Xã Sơn Linh,529
+21307,Xã Sơn Giang,529
+21310,Xã Sơn Trung,529
+21313,Xã Sơn Thượng,529
+21316,Xã Sơn Cao,529
+21319,Xã Sơn Hải,529
+21322,Xã Sơn Thủy,529
+21325,Xã Sơn Kỳ,529
+21328,Xã Sơn Ba,529
+21331,Xã Sơn Bua,530
+21334,Xã Sơn Mùa,530
+21335,Xã Sơn Liên,530
+21337,Xã Sơn Tân,530
+21338,Xã Sơn Màu,530
+21340,Xã Sơn Dung,530
+21341,Xã Sơn Long,530
+21343,Xã Sơn Tinh,530
+21346,Xã Sơn Lập,530
+21349,Xã Long Sơn,531
+21352,Xã Long Mai,531
+21355,Xã Thanh An,531
+21358,Xã Long Môn,531
+21361,Xã Long Hiệp,531
+21364,Thị trấn Chợ Chùa,532
+21367,Xã Hành Thuận,532
+21370,Xã Hành Dũng,532
+21373,Xã Hành Trung,532
+21376,Xã Hành Nhân,532
+21379,Xã Hành Đức,532
+21382,Xã Hành Minh,532
+21385,Xã Hành Phước,532
+21388,Xã Hành Thiện,532
+21391,Xã Hành Thịnh,532
+21394,Xã Hành Tín Tây,532
+21397,Xã Hành Tín  Đông,532
+21400,Thị trấn Mộ Đức,533
+21403,Xã Đức Lợi,533
+21406,Xã Đức Thắng,533
+21409,Xã Đức Nhuận,533
+21412,Xã Đức Chánh,533
+21415,Xã Đức Hiệp,533
+21418,Xã Đức Minh,533
+21421,Xã Đức Thạnh,533
+21424,Xã Đức Hòa,533
+21427,Xã Đức Tân,533
+21430,Xã Đức Phú,533
+21433,Xã Đức Phong,533
+21436,Xã Đức Lân,533
+21439,Phường Nguyễn Nghiêm,534
+21442,Xã Phổ An,534
+21445,Xã Phổ Phong,534
+21448,Xã Phổ Thuận,534
+21451,Phường Phổ Văn,534
+21454,Phường Phổ Quang,534
+21457,Xã Phổ Nhơn,534
+21460,Phường Phổ Ninh,534
+21463,Phường Phổ Minh,534
+21466,Phường Phổ Vinh,534
+21469,Phường Phổ Hòa,534
+21472,Xã Phổ Cường,534
+21475,Xã Phổ Khánh,534
+21478,Phường Phổ Thạnh,534
+21481,Xã Phổ Châu,534
+21484,Thị trấn Ba Tơ,535
+21487,Xã Ba Điền,535
+21490,Xã Ba Vinh,535
+21493,Xã Ba Thành,535
+21496,Xã Ba Động,535
+21499,Xã Ba Dinh,535
+21500,Xã Ba Giang,535
+21502,Xã Ba Liên,535
+21505,Xã Ba Ngạc,535
+21508,Xã Ba Khâm,535
+21511,Xã Ba Cung,535
+21517,Xã Ba Tiêu,535
+21520,Xã Ba Trang,535
+21523,Xã Ba Tô,535
+21526,Xã Ba Bích,535
+21529,Xã Ba Vì,535
+21532,Xã Ba Lế,535
+21535,Xã Ba Nam,535
+21538,Xã Ba Xa,535
+21550,Phường Nhơn Bình,540
+21553,Phường Nhơn Phú,540
+21556,Phường Đống Đa,540
+21559,Phường Trần Quang Diệu,540
+21562,Phường Hải Cảng,540
+21565,Phường Quang Trung,540
+21568,Phường Thị Nại,540
+21571,Phường Lê Hồng Phong,540
+21574,Phường Trần Hưng Đạo,540
+21577,Phường Ngô Mây,540
+21580,Phường Lý Thường Kiệt,540
+21583,Phường Lê Lợi,540
+21586,Phường Trần Phú,540
+21589,Phường Bùi Thị Xuân,540
+21592,Phường Nguyễn Văn Cừ,540
+21595,Phường Ghềnh Ráng,540
+21598,Xã Nhơn Lý,540
+21601,Xã Nhơn Hội,540
+21604,Xã Nhơn Hải,540
+21607,Xã Nhơn Châu,540
+21991,Xã Phước Mỹ,540
+21609,Thị trấn An Lão,542
+21610,Xã An Hưng,542
+21613,Xã An Trung,542
+21616,Xã An Dũng,542
+21619,Xã An Vinh,542
+21622,Xã An Toàn,542
+21625,Xã An Tân,542
+21628,Xã An Hòa,542
+21631,Xã An Quang,542
+21634,Xã An Nghĩa,542
+21637,Phường Tam Quan,543
+21640,Phường Bồng Sơn,543
+21643,Xã Hoài Sơn,543
+21646,Xã Hoài Châu Bắc,543
+21649,Xã Hoài Châu,543
+21652,Xã Hoài Phú,543
+21655,Phường Tam Quan Bắc,543
+21658,Phường Tam Quan Nam,543
+21661,Phường Hoài Hảo,543
+21664,Phường Hoài Thanh Tây,543
+21667,Phường Hoài Thanh,543
+21670,Phường Hoài Hương,543
+21673,Phường Hoài Tân,543
+21676,Xã Hoài Hải,543
+21679,Phường Hoài Xuân,543
+21682,Xã Hoài Mỹ,543
+21685,Phường Hoài Đức,543
+21688,Thị trấn Tăng Bạt Hổ,544
+21690,Xã Ân Hảo Tây,544
+21691,Xã Ân Hảo Đông,544
+21694,Xã Ân Sơn,544
+21697,Xã Ân Mỹ,544
+21700,Xã Đak Mang,544
+21703,Xã Ân Tín,544
+21706,Xã Ân Thạnh,544
+21709,Xã Ân Phong,544
+21712,Xã Ân Đức,544
+21715,Xã Ân Hữu,544
+21718,Xã Bok Tới,544
+21721,Xã Ân Tường Tây,544
+21724,Xã Ân Tường Đông,544
+21727,Xã Ân Nghĩa,544
+21730,Thị trấn Phù Mỹ,545
+21733,Thị trấn Bình Dương,545
+21736,Xã Mỹ Đức,545
+21739,Xã Mỹ Châu,545
+21742,Xã Mỹ Thắng,545
+21745,Xã Mỹ Lộc,545
+21748,Xã Mỹ Lợi,545
+21751,Xã Mỹ An,545
+21754,Xã Mỹ Phong,545
+21757,Xã Mỹ Trinh,545
+21760,Xã Mỹ Thọ,545
+21763,Xã Mỹ Hòa,545
+21766,Xã Mỹ Thành,545
+21769,Xã Mỹ Chánh,545
+21772,Xã Mỹ Quang,545
+21775,Xã Mỹ Hiệp,545
+21778,Xã Mỹ Tài,545
+21781,Xã Mỹ Cát,545
+21784,Xã Mỹ Chánh Tây,545
+21786,Thị trấn Vĩnh Thạnh,546
+21787,Xã Vĩnh Sơn,546
+21790,Xã Vĩnh Kim,546
+21796,Xã Vĩnh Hiệp,546
+21799,Xã Vĩnh Hảo,546
+21801,Xã Vĩnh Hòa,546
+21802,Xã Vĩnh Thịnh,546
+21804,Xã Vĩnh Thuận,546
+21805,Xã Vĩnh Quang,546
+21808,Thị trấn Phú Phong,547
+21811,Xã Bình Tân,547
+21814,Xã Tây Thuận,547
+21817,Xã Bình Thuận,547
+21820,Xã Tây Giang,547
+21823,Xã Bình Thành,547
+21826,Xã Tây An,547
+21829,Xã Bình Hòa,547
+21832,Xã Tây Bình,547
+21835,Xã Bình Tường,547
+21838,Xã Tây Vinh,547
+21841,Xã Vĩnh An,547
+21844,Xã Tây Xuân,547
+21847,Xã Bình Nghi,547
+21850,Xã Tây Phú,547
+21853,Thị trấn Ngô Mây,548
+21856,Xã Cát Sơn,548
+21859,Xã Cát Minh,548
+21862,Xã Cát Khánh,548
+21865,Xã Cát Tài,548
+21868,Xã Cát Lâm,548
+21871,Xã Cát Hanh,548
+21874,Xã Cát Thành,548
+21877,Xã Cát Trinh,548
+21880,Xã Cát Hải,548
+21883,Xã Cát Hiệp,548
+21886,Xã Cát Nhơn,548
+21889,Xã Cát Hưng,548
+21892,Xã Cát Tường,548
+21895,Xã Cát Tân,548
+21898,Thị trấn Cát Tiến,548
+21901,Xã Cát Thắng,548
+21904,Xã Cát Chánh,548
+21907,Phường Bình Định,549
+21910,Phường Đập Đá,549
+21913,Xã Nhơn Mỹ,549
+21916,Phường Nhơn Thành,549
+21919,Xã Nhơn Hạnh,549
+21922,Xã Nhơn Hậu,549
+21925,Xã Nhơn Phong,549
+21928,Xã Nhơn An,549
+21931,Xã Nhơn Phúc,549
+21934,Phường Nhơn Hưng,549
+21937,Xã Nhơn Khánh,549
+21940,Xã Nhơn Lộc,549
+21943,Phường Nhơn Hoà,549
+21946,Xã Nhơn Tân,549
+21949,Xã Nhơn Thọ,549
+21952,Thị trấn Tuy Phước,550
+21955,Thị trấn Diêu Trì,550
+21958,Xã Phước Thắng,550
+21961,Xã Phước Hưng,550
+21964,Xã Phước Quang,550
+21967,Xã Phước Hòa,550
+21970,Xã Phước Sơn,550
+21973,Xã Phước Hiệp,550
+21976,Xã Phước Lộc,550
+21979,Xã Phước Nghĩa,550
+21982,Xã Phước Thuận,550
+21985,Xã Phước An,550
+21988,Xã Phước Thành,550
+21994,Thị trấn Vân Canh,551
+21997,Xã Canh Liên,551
+22000,Xã Canh Hiệp,551
+22003,Xã Canh Vinh,551
+22006,Xã Canh Hiển,551
+22009,Xã Canh Thuận,551
+22012,Xã Canh Hòa,551
+22015,Phường 1,555
+22018,Phường 8,555
+22021,Phường 2,555
+22024,Phường 9,555
+22027,Phường 3,555
+22030,Phường 4,555
+22033,Phường 5,555
+22036,Phường 7,555
+22039,Phường 6,555
+22040,Phường Phú Thạnh,555
+22041,Phường Phú Đông,555
+22042,Xã Hòa Kiến,555
+22045,Xã Bình Kiến,555
+22048,Xã Bình Ngọc,555
+22162,Xã An Phú,555
+22240,Phường Phú Lâm,555
+22051,Phường Xuân Phú,557
+22052,Xã Xuân Lâm,557
+22053,Phường Xuân Thành,557
+22054,Xã Xuân Hải,557
+22057,Xã Xuân Lộc,557
+22060,Xã Xuân Bình,557
+22066,Xã Xuân Cảnh,557
+22069,Xã Xuân Thịnh,557
+22072,Xã Xuân Phương,557
+22073,Phường Xuân Yên,557
+22075,Xã Xuân Thọ 1,557
+22076,Phường Xuân Đài,557
+22078,Xã Xuân Thọ 2,557
+22081,Thị trấn La Hai,558
+22084,Xã Đa Lộc,558
+22087,Xã Phú Mỡ,558
+22090,Xã Xuân Lãnh,558
+22093,Xã Xuân Long,558
+22096,Xã Xuân Quang 1,558
+22099,Xã Xuân Sơn Bắc,558
+22102,Xã Xuân Quang 2,558
+22105,Xã Xuân Sơn Nam,558
+22108,Xã Xuân Quang 3,558
+22111,Xã Xuân Phước,558
+22114,Thị trấn Chí Thạnh,559
+22117,Xã An Dân,559
+22120,Xã An Ninh Tây,559
+22123,Xã An Ninh Đông,559
+22126,Xã An Thạch,559
+22129,Xã An Định,559
+22132,Xã An Nghiệp,559
+22138,Xã An Cư,559
+22141,Xã An Xuân,559
+22144,Xã An Lĩnh,559
+22147,Xã An Hòa Hải,559
+22150,Xã An Hiệp,559
+22153,Xã An Mỹ,559
+22156,Xã An Chấn,559
+22159,Xã An Thọ,559
+22165,Thị trấn Củng Sơn,560
+22168,Xã Phước Tân,560
+22171,Xã Sơn Hội,560
+22174,Xã Sơn Định,560
+22177,Xã Sơn Long,560
+22180,Xã Cà Lúi,560
+22183,Xã Sơn Phước,560
+22186,Xã Sơn Xuân,560
+22189,Xã Sơn Nguyên,560
+22192,Xã Eachà Rang,560
+22195,Xã Krông Pa,560
+22198,Xã Suối Bạc,560
+22201,Xã Sơn Hà,560
+22204,Xã Suối Trai,560
+22207,Thị trấn Hai Riêng,561
+22210,Xã Ea Lâm,561
+22213,Xã Đức Bình Tây,561
+22216,Xã Ea Bá,561
+22219,Xã Sơn Giang,561
+22222,Xã Đức Bình Đông,561
+22225,Xã EaBar,561
+22228,Xã EaBia,561
+22231,Xã EaTrol,561
+22234,Xã Sông Hinh,561
+22237,Xã Ealy,561
+22249,Xã Sơn Thành Tây,562
+22250,Xã Sơn Thành Đông,562
+22252,Xã Hòa Bình 1,562
+22255,Thị trấn Phú Thứ,562
+22264,Xã Hòa Phong,562
+22270,Xã Hòa Phú,562
+22273,Xã Hòa Tân Tây,562
+22276,Xã Hòa Đồng,562
+22285,Xã Hòa Mỹ Đông,562
+22288,Xã Hòa Mỹ Tây,562
+22294,Xã Hòa Thịnh,562
+22303,Xã Hòa Quang Bắc,563
+22306,Xã Hòa Quang Nam,563
+22309,Xã Hòa Hội,563
+22312,Xã Hòa Trị,563
+22315,Xã Hòa An,563
+22318,Xã Hòa Định Đông,563
+22319,Thị Trấn Phú Hoà,563
+22321,Xã Hòa Định Tây,563
+22324,Xã Hòa Thắng,563
+22243,Xã Hòa Thành,564
+22246,Phường Hòa Hiệp Bắc,564
+22258,Phường Hoà Vinh,564
+22261,Phường Hoà Hiệp Trung,564
+22267,Xã Hòa Tân Đông,564
+22279,Phường Hòa Xuân Tây,564
+22282,Phường Hòa Hiệp Nam,564
+22291,Xã Hòa Xuân Đông,564
+22297,Xã Hòa Tâm,564
+22300,Xã Hòa Xuân Nam,564
+22327,Phường Vĩnh Hòa,568
+22330,Phường Vĩnh Hải,568
+22333,Phường Vĩnh Phước,568
+22336,Phường Ngọc Hiệp,568
+22339,Phường Vĩnh Thọ,568
+22342,Phường Xương Huân,568
+22345,Phường Vạn Thắng,568
+22348,Phường Vạn Thạnh,568
+22351,Phường Phương Sài,568
+22354,Phường Phương Sơn,568
+22357,Phường Phước Hải,568
+22360,Phường Phước Tân,568
+22363,Phường Lộc Thọ,568
+22366,Phường Phước Tiến,568
+22369,Phường Tân Lập,568
+22372,Phường Phước Hòa,568
+22375,Phường Vĩnh Nguyên,568
+22378,Phường Phước Long,568
+22381,Phường Vĩnh Trường,568
+22384,Xã Vĩnh Lương,568
+22387,Xã Vĩnh Phương,568
+22390,Xã Vĩnh Ngọc,568
+22393,Xã Vĩnh Thạnh,568
+22396,Xã Vĩnh Trung,568
+22399,Xã Vĩnh Hiệp,568
+22402,Xã Vĩnh Thái,568
+22405,Xã Phước Đồng,568
+22408,Phường Cam Nghĩa,569
+22411,Phường Cam Phúc Bắc,569
+22414,Phường Cam Phúc Nam,569
+22417,Phường Cam Lộc,569
+22420,Phường Cam Phú,569
+22423,Phường Ba Ngòi,569
+22426,Phường Cam Thuận,569
+22429,Phường Cam Lợi,569
+22432,Phường Cam Linh,569
+22468,Xã Cam Thành Nam,569
+22474,Xã Cam Phước Đông,569
+22477,Xã Cam Thịnh Tây,569
+22480,Xã Cam Thịnh Đông,569
+22483,Xã Cam Lập,569
+22486,Xã Cam Bình,569
+22435,Xã Cam Tân,570
+22438,Xã Cam Hòa,570
+22441,Xã Cam Hải Đông,570
+22444,Xã Cam Hải Tây,570
+22447,Xã Sơn Tân,570
+22450,Xã Cam Hiệp Bắc,570
+22453,Thị trấn Cam Đức,570
+22456,Xã Cam Hiệp Nam,570
+22459,Xã Cam Phước Tây,570
+22462,Xã Cam Thành Bắc,570
+22465,Xã Cam An Bắc,570
+22471,Xã Cam An Nam,570
+22708,Xã Suối Cát,570
+22711,Xã Suối Tân,570
+22489,Thị trấn Vạn Giã,571
+22492,Xã Đại Lãnh,571
+22495,Xã Vạn Phước,571
+22498,Xã Vạn Long,571
+22501,Xã Vạn Bình,571
+22504,Xã Vạn Thọ,571
+22507,Xã Vạn Khánh,571
+22510,Xã Vạn Phú,571
+22513,Xã Vạn Lương,571
+22516,Xã Vạn Thắng,571
+22519,Xã Vạn Thạnh,571
+22522,Xã Xuân Sơn,571
+22525,Xã Vạn Hưng,571
+22528,Phường Ninh Hiệp,572
+22531,Xã Ninh Sơn,572
+22534,Xã Ninh Tây,572
+22537,Xã Ninh Thượng,572
+22540,Xã Ninh An,572
+22543,Phường Ninh Hải,572
+22546,Xã Ninh Thọ,572
+22549,Xã Ninh Trung,572
+22552,Xã Ninh Sim,572
+22555,Xã Ninh Xuân,572
+22558,Xã Ninh Thân,572
+22561,Phường Ninh Diêm,572
+22564,Xã Ninh Đông,572
+22567,Phường Ninh Thủy,572
+22570,Phường Ninh Đa,572
+22573,Xã Ninh Phụng,572
+22576,Xã Ninh Bình,572
+22579,Xã Ninh Phước,572
+22582,Xã Ninh Phú,572
+22585,Xã Ninh Tân,572
+22588,Xã Ninh Quang,572
+22591,Phường Ninh Giang,572
+22594,Phường Ninh Hà,572
+22597,Xã Ninh Hưng,572
+22600,Xã Ninh Lộc,572
+22603,Xã Ninh Ích,572
+22606,Xã Ninh Vân,572
+22609,Thị trấn Khánh Vĩnh,573
+22612,Xã Khánh Hiệp,573
+22615,Xã Khánh Bình,573
+22618,Xã Khánh Trung,573
+22621,Xã Khánh Đông,573
+22624,Xã Khánh Thượng,573
+22627,Xã Khánh Nam,573
+22630,Xã Sông Cầu,573
+22633,Xã Giang Ly,573
+22636,Xã Cầu Bà,573
+22639,Xã Liên Sang,573
+22642,Xã Khánh Thành,573
+22645,Xã Khánh Phú,573
+22648,Xã Sơn Thái,573
+22651,Thị trấn Diên Khánh,574
+22654,Xã Diên Lâm,574
+22657,Xã Diên Điền,574
+22660,Xã Diên Xuân,574
+22663,Xã Diên Sơn,574
+22666,Xã Diên Đồng,574
+22669,Xã Diên Phú,574
+22672,Xã Diên Thọ,574
+22675,Xã Diên Phước,574
+22678,Xã Diên Lạc,574
+22681,Xã Diên Tân,574
+22684,Xã Diên Hòa,574
+22687,Xã Diên Thạnh,574
+22690,Xã Diên Toàn,574
+22693,Xã Diên An,574
+22696,Xã Bình Lộc,574
+22702,Xã Suối Hiệp,574
+22705,Xã Suối Tiên,574
+22714,Thị trấn Tô Hạp,575
+22717,Xã Thành Sơn,575
+22720,Xã Sơn Lâm,575
+22723,Xã Sơn Hiệp,575
+22726,Xã Sơn Bình,575
+22729,Xã Sơn Trung,575
+22732,Xã Ba Cụm Bắc,575
+22735,Xã Ba Cụm Nam,575
+22736,Thị trấn Trường Sa,576
+22737,Xã Song Tử Tây,576
+22739,Xã Sinh Tồn,576
+22738,Phường Đô Vinh,582
+22741,Phường Phước Mỹ,582
+22744,Phường Bảo An,582
+22747,Phường Phủ Hà,582
+22750,Phường Thanh Sơn,582
+22753,Phường Mỹ Hương,582
+22756,Phường Tấn Tài,582
+22759,Phường Kinh Dinh,582
+22762,Phường Đạo Long,582
+22765,Phường Đài Sơn,582
+22768,Phường Đông Hải,582
+22771,Phường Mỹ Đông,582
+22774,Xã Thành Hải,582
+22777,Phường Văn Hải,582
+22779,Phường Mỹ Bình,582
+22780,Phường Mỹ Hải,582
+22783,Xã Phước Bình,584
+22786,Xã Phước Hòa,584
+22789,Xã Phước Tân,584
+22792,Xã Phước Tiến,584
+22795,Xã Phước Thắng,584
+22798,Xã Phước Thành,584
+22801,Xã Phước Đại,584
+22804,Xã Phước Chính,584
+22807,Xã Phước Trung,584
+22810,Thị trấn Tân Sơn,585
+22813,Xã Lâm Sơn,585
+22816,Xã Lương Sơn,585
+22819,Xã Quảng Sơn,585
+22822,Xã Mỹ Sơn,585
+22825,Xã Hòa Sơn,585
+22828,Xã Ma Nới,585
+22831,Xã Nhơn Sơn,585
+22834,Thị trấn Khánh Hải,586
+22846,Xã Vĩnh Hải,586
+22852,Xã Phương Hải,586
+22855,Xã Tân Hải,586
+22858,Xã Xuân Hải,586
+22861,Xã Hộ Hải,586
+22864,Xã Tri Hải,586
+22867,Xã Nhơn Hải,586
+22868,Xã Thanh Hải,586
+22870,Thị trấn Phước Dân,587
+22873,Xã Phước Sơn,587
+22876,Xã Phước Thái,587
+22879,Xã Phước Hậu,587
+22882,Xã Phước Thuận,587
+22888,Xã An Hải,587
+22891,Xã Phước Hữu,587
+22894,Xã Phước Hải,587
+22912,Xã Phước Vinh,587
+22837,Xã Phước Chiến,588
+22840,Xã Công Hải,588
+22843,Xã Phước Kháng,588
+22849,Xã Lợi Hải,588
+22853,Xã Bắc Sơn,588
+22856,Xã Bắc Phong,588
+22885,Xã Phước Hà,589
+22897,Xã Phước Nam,589
+22898,Xã Phước Ninh,589
+22900,Xã Nhị Hà,589
+22903,Xã Phước Dinh,589
+22906,Xã Phước Minh,589
+22909,Xã Phước Diêm,589
+22910,Xã Cà Ná,589
+22915,Phường Mũi Né,593
+22918,Phường Hàm Tiến,593
+22921,Phường Phú Hài,593
+22924,Phường Phú Thủy,593
+22927,Phường Phú Tài,593
+22930,Phường Phú Trinh,593
+22933,Phường Xuân An,593
+22936,Phường Thanh Hải,593
+22939,Phường Bình Hưng,593
+22942,Phường Đức Nghĩa,593
+22945,Phường Lạc Đạo,593
+22948,Phường Đức Thắng,593
+22951,Phường Hưng Long,593
+22954,Phường Đức Long,593
+22957,Xã Thiện Nghiệp,593
+22960,Xã Phong Nẫm,593
+22963,Xã Tiến Lợi,593
+22966,Xã Tiến Thành,593
+23231,Phường Phước Hội,594
+23232,Phường Phước Lộc,594
+23234,Phường Tân Thiện,594
+23235,Phường Tân An,594
+23237,Phường Bình Tân,594
+23245,Xã Tân Hải,594
+23246,Xã Tân Tiến,594
+23248,Xã Tân Bình,594
+23268,Xã Tân Phước,594
+22969,Thị trấn Liên Hương,595
+22972,Thị trấn Phan Rí Cửa,595
+22975,Xã Phan Dũng,595
+22978,Xã Phong Phú,595
+22981,Xã Vĩnh Hảo,595
+22984,Xã Vĩnh Tân,595
+22987,Xã Phú Lạc,595
+22990,Xã Phước Thể,595
+22993,Xã Hòa Minh,595
+22996,Xã Chí Công,595
+22999,Xã Bình Thạnh,595
+23005,Thị trấn Chợ Lầu,596
+23008,Xã Phan Sơn,596
+23011,Xã Phan Lâm,596
+23014,Xã Bình An,596
+23017,Xã Phan Điền,596
+23020,Xã Hải Ninh,596
+23023,Xã Sông Lũy,596
+23026,Xã Phan Tiến,596
+23029,Xã Sông Bình,596
+23032,Thị trấn Lương Sơn,596
+23035,Xã Phan Hòa,596
+23038,Xã Phan Thanh,596
+23041,Xã Hồng Thái,596
+23044,Xã Phan Hiệp,596
+23047,Xã Bình Tân,596
+23050,Xã Phan Rí Thành,596
+23053,Xã Hòa Thắng,596
+23056,Xã Hồng Phong,596
+23059,Thị trấn Ma Lâm,597
+23062,Thị trấn Phú Long,597
+23065,Xã La Dạ,597
+23068,Xã Đông Tiến,597
+23071,Xã Thuận Hòa,597
+23074,Xã Đông Giang,597
+23077,Xã Hàm Phú,597
+23080,Xã Hồng Liêm,597
+23083,Xã Thuận Minh,597
+23086,Xã Hồng Sơn,597
+23089,Xã Hàm Trí,597
+23092,Xã Hàm Đức,597
+23095,Xã Hàm Liêm,597
+23098,Xã Hàm Chính,597
+23101,Xã Hàm Hiệp,597
+23104,Xã Hàm Thắng,597
+23107,Xã Đa Mi,597
+23110,Thị trấn Thuận Nam,598
+23113,Xã Mỹ Thạnh,598
+23116,Xã Hàm Cần,598
+23119,Xã Mương Mán,598
+23122,Xã Hàm Thạnh,598
+23125,Xã Hàm Kiệm,598
+23128,Xã Hàm Cường,598
+23131,Xã Hàm Mỹ,598
+23134,Xã Tân Lập,598
+23137,Xã Hàm Minh,598
+23140,Xã Thuận Quí,598
+23143,Xã Tân Thuận,598
+23146,Xã Tân Thành,598
+23149,Thị trấn Lạc Tánh,599
+23152,Xã Bắc Ruộng,599
+23158,Xã Nghị Đức,599
+23161,Xã La Ngâu,599
+23164,Xã Huy Khiêm,599
+23167,Xã Măng Tố,599
+23170,Xã Đức Phú,599
+23173,Xã Đồng Kho,599
+23176,Xã Gia An,599
+23179,Xã Đức Bình,599
+23182,Xã Gia Huynh,599
+23185,Xã Đức Thuận,599
+23188,Xã Suối Kiết,599
+23191,Thị trấn Võ Xu,600
+23194,Thị trấn Đức Tài,600
+23197,Xã Đa Kai,600
+23200,Xã Sùng Nhơn,600
+23203,Xã Mê Pu,600
+23206,Xã Nam Chính,600
+23212,Xã Đức Hạnh,600
+23215,Xã Đức Tín,600
+23218,Xã Vũ Hoà,600
+23221,Xã Tân Hà,600
+23224,Xã Đông Hà,600
+23227,Xã Trà Tân,600
+23230,Thị trấn Tân Minh,601
+23236,Thị trấn Tân Nghĩa,601
+23239,Xã Sông Phan,601
+23242,Xã Tân Phúc,601
+23251,Xã Tân Đức,601
+23254,Xã Tân Thắng,601
+23255,Xã Thắng Hải,601
+23257,Xã Tân Hà,601
+23260,Xã Tân Xuân,601
+23266,Xã Sơn Mỹ,601
+23272,Xã Ngũ Phụng,602
+23275,Xã Long Hải,602
+23278,Xã Tam Thanh,602
+23281,Phường Quang Trung,608
+23284,Phường Duy Tân,608
+23287,Phường Quyết Thắng,608
+23290,Phường Trường Chinh,608
+23293,Phường Thắng Lợi,608
+23296,Phường Ngô Mây,608
+23299,Phường Thống Nhất,608
+23302,Phường Lê Lợi,608
+23305,Phường Nguyễn Trãi,608
+23308,Phường Trần Hưng Đạo,608
+23311,Xã Đắk Cấm,608
+23314,Xã Kroong,608
+23317,Xã Ngọk Bay,608
+23320,Xã Vinh Quang,608
+23323,Xã Đắk Blà,608
+23326,Xã Ia Chim,608
+23327,Xã Đăk Năng,608
+23329,Xã Đoàn Kết,608
+23332,Xã Chư Hreng,608
+23335,Xã Đắk Rơ Wa,608
+23338,Xã Hòa Bình,608
+23341,Thị trấn Đắk Glei,610
+23344,Xã Đắk Blô,610
+23347,Xã Đắk Man,610
+23350,Xã Đắk Nhoong,610
+23353,Xã Đắk Pék,610
+23356,Xã Đắk Choong,610
+23359,Xã Xốp,610
+23362,Xã Mường Hoong,610
+23365,Xã Ngọc Linh,610
+23368,Xã Đắk Long,610
+23371,Xã Đắk KRoong,610
+23374,Xã Đắk Môn,610
+23377,Thị trấn Plei Kần,611
+23380,Xã Đắk Ang,611
+23383,Xã Đắk Dục,611
+23386,Xã Đắk Nông,611
+23389,Xã Đắk Xú,611
+23392,Xã Đắk Kan,611
+23395,Xã Bờ Y,611
+23398,Xã Sa Loong,611
+23401,Thị trấn Đắk Tô,612
+23427,Xã Đắk Rơ Nga,612
+23428,Xã Ngọk Tụ,612
+23430,Xã Đắk Trăm,612
+23431,Xã Văn Lem,612
+23434,Xã Kon Đào,612
+23437,Xã Tân Cảnh,612
+23440,Xã Diên Bình,612
+23443,Xã Pô Kô,612
+23452,Xã Đắk Nên,613
+23455,Xã Đắk Ring,613
+23458,Xã Măng Buk,613
+23461,Xã Đắk Tăng,613
+23464,Xã Ngok Tem,613
+23467,Xã Pờ Ê,613
+23470,Xã Măng Cành,613
+23473,Thị trấn Măng Đen,613
+23476,Xã Hiếu,613
+23479,Thị trấn Đắk Rve,614
+23482,Xã Đắk Kôi,614
+23485,Xã Đắk Tơ Lung,614
+23488,Xã Đắk Ruồng,614
+23491,Xã Đắk Pne,614
+23494,Xã Đắk Tờ Re,614
+23497,Xã Tân Lập,614
+23500,Thị trấn Đắk Hà,615
+23503,Xã Đắk PXi,615
+23504,Xã Đăk Long,615
+23506,Xã Đắk HRing,615
+23509,Xã Đắk Ui,615
+23510,Xã Đăk Ngọk,615
+23512,Xã Đắk Mar,615
+23515,Xã Ngok Wang,615
+23518,Xã Ngok Réo,615
+23521,Xã Hà Mòn,615
+23524,Xã Đắk La,615
+23527,Thị trấn Sa Thầy,616
+23530,Xã Rơ Kơi,616
+23533,Xã Sa Nhơn,616
+23534,Xã Hơ Moong,616
+23536,Xã Mô Rai,616
+23539,Xã Sa Sơn,616
+23542,Xã Sa Nghĩa,616
+23545,Xã Sa Bình,616
+23548,Xã Ya Xiêr,616
+23551,Xã Ya Tăng,616
+23554,Xã Ya ly,616
+23404,Xã Ngọc Lây,617
+23407,Xã Đắk Na,617
+23410,Xã Măng Ri,617
+23413,Xã Ngọc Yêu,617
+23416,Xã Đắk Sao,617
+23417,Xã Đắk Rơ Ông,617
+23419,Xã Đắk Tờ Kan,617
+23422,Xã Tu Mơ Rông,617
+23425,Xã Đắk Hà,617
+23446,Xã Tê Xăng,617
+23449,Xã Văn Xuôi,617
+23535,Xã Ia Đal,618
+23537,Xã Ia Dom,618
+23538,Xã Ia Tơi,618
+23557,Phường Yên Đỗ,622
+23560,Phường Diên Hồng,622
+23563,Phường Ia Kring,622
+23566,Phường Hội Thương,622
+23569,Phường Hội Phú,622
+23570,Phường Phù Đổng,622
+23572,Phường Hoa Lư,622
+23575,Phường Tây Sơn,622
+23578,Phường Thống Nhất,622
+23579,Phường Đống Đa,622
+23581,Phường Trà Bá,622
+23582,Phường Thắng Lợi,622
+23584,Phường Yên Thế,622
+23586,Phường Chi Lăng,622
+23590,Xã Biển Hồ,622
+23593,Xã Tân Sơn,622
+23596,Xã Trà Đa,622
+23599,Xã Chư Á,622
+23602,Xã An Phú,622
+23605,Xã Diên Phú,622
+23608,Xã Ia Kênh,622
+23611,Xã Gào,622
+23614,Phường An Bình,623
+23617,Phường Tây Sơn,623
+23620,Phường An Phú,623
+23623,Phường An Tân,623
+23626,Xã Tú An,623
+23627,Xã Xuân An,623
+23629,Xã Cửu An,623
+23630,Phường An Phước,623
+23632,Xã Song An,623
+23633,Phường Ngô Mây,623
+23635,Xã Thành An,623
+24041,Phường Cheo Reo,624
+24042,Phường Hòa Bình,624
+24044,Phường Đoàn Kết,624
+24045,Phường Sông Bờ,624
+24064,Xã Ia RBol,624
+24065,Xã Chư Băh,624
+24070,Xã Ia RTô,624
+24073,Xã Ia Sao,624
+23638,Thị trấn KBang,625
+23641,Xã Kon Pne,625
+23644,Xã Đăk Roong,625
+23647,Xã Sơn Lang,625
+23650,Xã KRong,625
+23653,Xã Sơ Pai,625
+23656,Xã Lơ Ku,625
+23659,Xã Đông,625
+23660,Xã Đak SMar,625
+23662,Xã Nghĩa An,625
+23665,Xã Tơ Tung,625
+23668,Xã Kông Lơng Khơng,625
+23671,Xã Kông Pla,625
+23674,Xã Đăk HLơ,625
+23677,Thị trấn Đăk Đoa,626
+23680,Xã Hà Đông,626
+23683,Xã Đăk Sơmei,626
+23684,Xã Đăk Krong,626
+23686,Xã Hải Yang,626
+23689,Xã Kon Gang,626
+23692,Xã Hà Bầu,626
+23695,Xã Nam Yang,626
+23698,Xã K' Dang,626
+23701,Xã H' Neng,626
+23704,Xã Tân Bình,626
+23707,Xã Glar,626
+23710,Xã A Dơk,626
+23713,Xã Trang,626
+23714,Xã HNol,626
+23716,Xã Ia Pết,626
+23719,Xã Ia Băng,626
+23722,Thị trấn Phú Hòa,627
+23725,Xã Hà Tây,627
+23728,Xã Ia Khươl,627
+23731,Xã Ia Phí,627
+23734,Thị trấn Ia Ly,627
+23737,Xã Ia Mơ Nông,627
+23738,Xã Ia Kreng,627
+23740,Xã Đăk Tơ Ver,627
+23743,Xã Hòa Phú,627
+23746,Xã Chư Đăng Ya,627
+23749,Xã Ia Ka,627
+23752,Xã Ia Nhin,627
+23755,Xã Nghĩa Hòa,627
+23761,Xã Nghĩa Hưng,627
+23764,Thị trấn Ia Kha,628
+23767,Xã Ia Sao,628
+23768,Xã Ia Yok,628
+23770,Xã Ia Hrung,628
+23771,Xã Ia Bă,628
+23773,Xã Ia Khai,628
+23776,Xã Ia KRai,628
+23778,Xã Ia Grăng,628
+23779,Xã Ia Tô,628
+23782,Xã Ia O,628
+23785,Xã Ia Dêr,628
+23788,Xã Ia Chia,628
+23791,Xã Ia Pếch,628
+23794,Thị trấn Kon Dơng,629
+23797,Xã Ayun,629
+23798,Xã Đak Jơ Ta,629
+23799,Xã Đak Ta Ley,629
+23800,Xã Hra,629
+23803,Xã Đăk Yă,629
+23806,Xã Đăk Djrăng,629
+23809,Xã Lơ Pang,629
+23812,Xã Kon Thụp,629
+23815,Xã Đê Ar,629
+23818,Xã Kon Chiêng,629
+23821,Xã Đăk Trôi,629
+23824,Thị trấn Kông Chro,630
+23827,Xã Chư Krêy,630
+23830,Xã An Trung,630
+23833,Xã Kông Yang,630
+23836,Xã Đăk Tơ Pang,630
+23839,Xã SRó,630
+23840,Xã Đắk Kơ Ning,630
+23842,Xã Đăk Song,630
+23843,Xã Đăk Pling,630
+23845,Xã Yang Trung,630
+23846,Xã Đăk Pơ Pho,630
+23848,Xã Ya Ma,630
+23851,Xã Chơ Long,630
+23854,Xã Yang Nam,630
+23857,Thị trấn Chư Ty,631
+23860,Xã Ia Dơk,631
+23863,Xã Ia Krêl,631
+23866,Xã Ia Din,631
+23869,Xã Ia Kla,631
+23872,Xã Ia Dom,631
+23875,Xã Ia Lang,631
+23878,Xã Ia Kriêng,631
+23881,Xã Ia Pnôn,631
+23884,Xã Ia Nan,631
+23887,Thị trấn Chư Prông,632
+23888,Xã Ia Kly,632
+23890,Xã Bình Giáo,632
+23893,Xã Ia Drăng,632
+23896,Xã Thăng Hưng,632
+23899,Xã Bàu Cạn,632
+23902,Xã Ia Phìn,632
+23905,Xã Ia Băng,632
+23908,Xã Ia Tôr,632
+23911,Xã Ia Boòng,632
+23914,Xã Ia O,632
+23917,Xã Ia Púch,632
+23920,Xã Ia Me,632
+23923,Xã Ia Vê,632
+23924,Xã Ia Bang,632
+23926,Xã Ia Pia,632
+23929,Xã Ia Ga,632
+23932,Xã Ia Lâu,632
+23935,Xã Ia Piơr,632
+23938,Xã Ia Mơ,632
+23941,Thị trấn Chư Sê,633
+23944,Xã Ia Tiêm,633
+23945,Xã Chư Pơng,633
+23946,Xã Bar Măih,633
+23947,Xã Bờ Ngoong,633
+23950,Xã Ia Glai,633
+23953,Xã AL Bá,633
+23954,Xã Kông HTok,633
+23956,Xã AYun,633
+23959,Xã Ia HLốp,633
+23962,Xã Ia Blang,633
+23965,Xã Dun,633
+23966,Xã Ia Pal,633
+23968,Xã H Bông,633
+23977,Xã Ia Ko,633
+23989,Xã Hà Tam,634
+23992,Xã An Thành,634
+23995,Thị trấn Đak Pơ,634
+23998,Xã Yang Bắc,634
+24001,Xã Cư An,634
+24004,Xã Tân An,634
+24007,Xã Phú An,634
+24010,Xã Ya Hội,634
+24013,Xã Pờ Tó,635
+24016,Xã Chư Răng,635
+24019,Xã Ia KDăm,635
+24022,Xã Kim Tân,635
+24025,Xã Chư Mố,635
+24028,Xã Ia Tul,635
+24031,Xã Ia Ma Rơn,635
+24034,Xã Ia Broăi,635
+24037,Xã Ia Trok,635
+24076,Thị trấn Phú Túc,637
+24079,Xã Ia RSai,637
+24082,Xã Ia RSươm,637
+24085,Xã Chư Gu,637
+24088,Xã Đất Bằng,637
+24091,Xã Ia Mláh,637
+24094,Xã Chư Drăng,637
+24097,Xã Phú Cần,637
+24100,Xã Ia HDreh,637
+24103,Xã Ia RMok,637
+24106,Xã Chư Ngọc,637
+24109,Xã Uar,637
+24112,Xã Chư Rcăm,637
+24115,Xã Krông Năng,637
+24043,Thị trấn Phú Thiện,638
+24046,Xã Chư A Thai,638
+24048,Xã Ayun Hạ,638
+24049,Xã Ia Ake,638
+24052,Xã Ia Sol,638
+24055,Xã Ia Piar,638
+24058,Xã Ia Peng,638
+24060,Xã Chrôh Pơnan,638
+24061,Xã Ia Hiao,638
+24067,Xã Ia Yeng,638
+23942,Thị trấn Nhơn Hoà,639
+23971,Xã Ia Hrú,639
+23972,Xã Ia Rong,639
+23974,Xã Ia Dreng,639
+23978,Xã Ia Hla,639
+23980,Xã Chư Don,639
+23983,Xã Ia Phang,639
+23986,Xã Ia Le,639
+23987,Xã Ia BLứ,639
+24118,Phường Tân Lập,643
+24121,Phường Tân Hòa,643
+24124,Phường Tân An,643
+24127,Phường Thống Nhất,643
+24130,Phường Thành Nhất,643
+24133,Phường Thắng Lợi,643
+24136,Phường Tân Lợi,643
+24139,Phường Thành Công,643
+24142,Phường Tân Thành,643
+24145,Phường Tân Tiến,643
+24148,Phường Tự An,643
+24151,Phường Ea Tam,643
+24154,Phường Khánh Xuân,643
+24157,Xã Hòa Thuận,643
+24160,Xã Cư ÊBur,643
+24163,Xã Ea Tu,643
+24166,Xã Hòa Thắng,643
+24169,Xã Ea Kao,643
+24172,Xã Hòa Phú,643
+24175,Xã Hòa Khánh,643
+24178,Xã Hòa Xuân,643
+24305,Phường An Lạc,644
+24308,Phường An Bình,644
+24311,Phường Thiện An,644
+24318,Phường Đạt Hiếu,644
+24322,Phường Đoàn Kết,644
+24325,Xã Ea Blang,644
+24328,Xã Ea Drông,644
+24331,Phường Thống Nhất,644
+24332,Phường Bình Tân,644
+24334,Xã Ea Siên,644
+24337,Xã Bình Thuận,644
+24340,Xã Cư Bao,644
+24181,Thị trấn Ea Drăng,645
+24184,Xã Ea H'leo,645
+24187,Xã Ea Sol,645
+24190,Xã Ea Ral,645
+24193,Xã Ea Wy,645
+24194,Xã Cư A Mung,645
+24196,Xã Cư Mốt,645
+24199,Xã Ea Hiao,645
+24202,Xã Ea Khal,645
+24205,Xã Dliê Yang,645
+24207,Xã Ea Tir,645
+24208,Xã Ea Nam,645
+24211,Thị trấn Ea Súp,646
+24214,Xã Ia Lốp,646
+24215,Xã Ia JLơi,646
+24217,Xã Ea Rốk,646
+24220,Xã Ya Tờ Mốt,646
+24221,Xã Ia RVê,646
+24223,Xã Ea Lê,646
+24226,Xã Cư KBang,646
+24229,Xã Ea Bung,646
+24232,Xã Cư M'Lan,646
+24235,Xã Krông Na,647
+24238,Xã Ea Huar,647
+24241,Xã Ea Wer,647
+24244,Xã Tân Hoà,647
+24247,Xã Cuôr KNia,647
+24250,Xã Ea Bar,647
+24253,Xã Ea Nuôl,647
+24256,Thị trấn Ea Pốk,648
+24259,Thị trấn Quảng Phú,648
+24262,Xã Quảng Tiến,648
+24264,Xã Ea Kuêh,648
+24265,Xã Ea Kiết,648
+24268,Xã Ea Tar,648
+24271,Xã Cư Dliê M'nông,648
+24274,Xã Ea H'đinh,648
+24277,Xã Ea Tul,648
+24280,Xã Ea KPam,648
+24283,Xã Ea M'DRóh,648
+24286,Xã Quảng Hiệp,648
+24289,Xã Cư M'gar,648
+24292,Xã Ea D'Rơng,648
+24295,Xã Ea M'nang,648
+24298,Xã Cư Suê,648
+24301,Xã Cuor Đăng,648
+24307,Xã Cư Né,649
+24310,Xã Chư KBô,649
+24313,Xã Cư Pơng,649
+24314,Xã Ea Sin,649
+24316,Xã Pơng Drang,649
+24317,Xã Tân Lập,649
+24319,Xã Ea Ngai,649
+24343,Thị trấn Krông Năng,650
+24346,Xã ĐLiê Ya,650
+24349,Xã Ea Tóh,650
+24352,Xã Ea Tam,650
+24355,Xã Phú Lộc,650
+24358,Xã Tam Giang,650
+24359,Xã Ea Puk,650
+24360,Xã Ea Dăh,650
+24361,Xã Ea Hồ,650
+24364,Xã Phú Xuân,650
+24367,Xã Cư Klông,650
+24370,Xã Ea Tân,650
+24373,Thị trấn Ea Kar,651
+24376,Thị trấn Ea Knốp,651
+24379,Xã Ea Sô,651
+24380,Xã Ea Sar,651
+24382,Xã Xuân Phú,651
+24385,Xã Cư Huê,651
+24388,Xã Ea Tih,651
+24391,Xã Ea Đar,651
+24394,Xã Ea Kmút,651
+24397,Xã Cư Ni,651
+24400,Xã Ea Păl,651
+24401,Xã Cư Prông,651
+24403,Xã Ea Ô,651
+24404,Xã Cư ELang,651
+24406,Xã Cư Bông,651
+24409,Xã Cư Jang,651
+24412,Thị trấn M'Đrắk,652
+24415,Xã Cư Prao,652
+24418,Xã Ea Pil,652
+24421,Xã Ea Lai,652
+24424,Xã Ea H'MLay,652
+24427,Xã Krông Jing,652
+24430,Xã Ea M' Doal,652
+24433,Xã Ea Riêng,652
+24436,Xã Cư M'ta,652
+24439,Xã Cư K Róa,652
+24442,Xã Krông Á,652
+24444,Xã Cư San,652
+24445,Xã Ea Trang,652
+24448,Thị trấn Krông Kmar,653
+24451,Xã Dang Kang,653
+24454,Xã Cư KTy,653
+24457,Xã Hòa Thành,653
+24460,Xã Hòa Tân,653
+24463,Xã Hòa Phong,653
+24466,Xã Hòa Lễ,653
+24469,Xã Yang Reh,653
+24472,Xã Ea Trul,653
+24475,Xã Khuê Ngọc Điền,653
+24478,Xã Cư Pui,653
+24481,Xã Hòa Sơn,653
+24484,Xã Cư Drăm,653
+24487,Xã Yang Mao,653
+24490,Thị trấn Phước An,654
+24493,Xã KRông Búk,654
+24496,Xã Ea Kly,654
+24499,Xã Ea Kênh,654
+24502,Xã Ea Phê,654
+24505,Xã Ea KNuec,654
+24508,Xã Ea Yông,654
+24511,Xã Hòa An,654
+24514,Xã Ea Kuăng,654
+24517,Xã Hòa Đông,654
+24520,Xã Ea Hiu,654
+24523,Xã Hòa Tiến,654
+24526,Xã Tân Tiến,654
+24529,Xã Vụ Bổn,654
+24532,Xã Ea Uy,654
+24535,Xã Ea Yiêng,654
+24538,Thị trấn Buôn Trấp,655
+24556,Xã Dray Sáp,655
+24559,Xã Ea Na,655
+24565,Xã Ea Bông,655
+24568,Xã Băng A Drênh,655
+24571,Xã Dur KMăl,655
+24574,Xã Bình Hòa,655
+24577,Xã Quảng Điền,655
+24580,Thị trấn Liên Sơn,656
+24583,Xã Yang Tao,656
+24586,Xã Bông Krang,656
+24589,Xã Đắk Liêng,656
+24592,Xã Buôn Triết,656
+24595,Xã Buôn Tría,656
+24598,Xã Đắk Phơi,656
+24601,Xã Đắk Nuê,656
+24604,Xã Krông Nô,656
+24607,Xã Nam Ka,656
+24610,Xã Ea R'Bin,656
+24540,Xã Ea Ning,657
+24541,Xã Cư Ê Wi,657
+24544,Xã Ea Ktur,657
+24547,Xã Ea Tiêu,657
+24550,Xã Ea BHốk,657
+24553,Xã Ea Hu,657
+24561,Xã Dray Bhăng,657
+24562,Xã Hòa Hiệp,657
+24611,Phường Nghĩa Đức,660
+24612,Phường Nghĩa Thành,660
+24614,Phường Nghĩa Phú,660
+24615,Phường Nghĩa Tân,660
+24617,Phường Nghĩa Trung,660
+24618,Xã Đăk R'Moan,660
+24619,Phường Quảng Thành,660
+24628,Xã Đắk Nia,660
+24616,Xã Quảng Sơn,661
+24620,Xã Quảng Hoà,661
+24622,Xã Đắk Ha,661
+24625,Xã Đắk R'Măng,661
+24631,Xã Quảng Khê,661
+24634,Xã Đắk Plao,661
+24637,Xã Đắk Som,661
+24640,Thị trấn Ea T'Ling,662
+24643,Xã Đắk Wil,662
+24646,Xã Ea Pô,662
+24649,Xã Nam Dong,662
+24652,Xã Đắk DRông,662
+24655,Xã Tâm Thắng,662
+24658,Xã Cư Knia,662
+24661,Xã Trúc Sơn,662
+24664,Thị trấn Đắk Mil,663
+24667,Xã  Đắk Lao,663
+24670,Xã Đắk R'La,663
+24673,Xã Đắk Gằn,663
+24676,Xã Đức Mạnh,663
+24677,Xã Đắk N'Drót,663
+24678,Xã Long Sơn,663
+24679,Xã Đắk Sắk,663
+24682,Xã Thuận An,663
+24685,Xã Đức Minh,663
+24688,Thị trấn Đắk Mâm,664
+24691,Xã Đắk Sôr,664
+24692,Xã Nam Xuân,664
+24694,Xã Buôn Choah,664
+24697,Xã Nam Đà,664
+24699,Xã Tân Thành,664
+24700,Xã Đắk Drô,664
+24703,Xã Nâm Nung,664
+24706,Xã Đức Xuyên,664
+24709,Xã Đắk Nang,664
+24712,Xã Quảng Phú,664
+24715,Xã Nâm N'Đir,664
+24717,Thị trấn Đức An,665
+24718,Xã Đắk Môl,665
+24719,Xã Đắk Hòa,665
+24721,Xã Nam Bình,665
+24722,Xã Thuận Hà,665
+24724,Xã Thuận Hạnh,665
+24727,Xã Đắk N'Dung,665
+24728,Xã Nâm N'Jang,665
+24730,Xã Trường Xuân,665
+24733,Thị trấn Kiến Đức,666
+24745,Xã Quảng Tín,666
+24750,Xã Đắk Wer,666
+24751,Xã Nhân Cơ,666
+24754,Xã Kiến Thành,666
+24756,Xã Nghĩa Thắng,666
+24757,Xã Đạo Nghĩa,666
+24760,Xã Đắk Sin,666
+24761,Xã Hưng Bình,666
+24763,Xã Đắk Ru,666
+24766,Xã Nhân Đạo,666
+24736,Xã Quảng Trực,667
+24739,Xã Đắk Búk So,667
+24740,Xã Quảng Tâm,667
+24742,Xã Đắk R'Tíh,667
+24746,Xã Đắk Ngo,667
+24748,Xã Quảng Tân,667
+24769,Phường 7,672
+24772,Phường 8,672
+24775,Phường 12,672
+24778,Phường 9,672
+24781,Phường 2,672
+24784,Phường 1,672
+24787,Phường 6,672
+24790,Phường 5,672
+24793,Phường 4,672
+24796,Phường 10,672
+24799,Phường 11,672
+24802,Phường 3,672
+24805,Xã Xuân Thọ,672
+24808,Xã Tà Nung,672
+24810,Xã Trạm Hành,672
+24811,Xã Xuân Trường,672
+24814,Phường Lộc Phát,673
+24817,Phường Lộc Tiến,673
+24820,Phường 2,673
+24823,Phường 1,673
+24826,Phường B'lao,673
+24829,Phường Lộc Sơn,673
+24832,Xã Đạm Bri,673
+24835,Xã Lộc Thanh,673
+24838,Xã Lộc Nga,673
+24841,Xã Lộc Châu,673
+24844,Xã Đại Lào,673
+24853,Xã Đạ Tông,674
+24856,Xã Đạ Long,674
+24859,Xã Đạ M' Rong,674
+24874,Xã Liêng Srônh,674
+24875,Xã Đạ Rsal,674
+24877,Xã Rô Men,674
+24886,Xã Phi Liêng,674
+24889,Xã Đạ K' Nàng,674
+24846,Thị trấn Lạc Dương,675
+24847,Xã Đạ Chais,675
+24848,Xã Đạ Nhim,675
+24850,Xã Đưng KNớ,675
+24862,Xã Lát,675
+24865,Xã Đạ Sar,675
+24868,Thị trấn Nam Ban,676
+24871,Thị trấn Đinh Văn,676
+24880,Xã Phú Sơn,676
+24883,Xã Phi Tô,676
+24892,Xã Mê Linh,676
+24895,Xã Đạ Đờn,676
+24898,Xã Phúc Thọ,676
+24901,Xã Đông Thanh,676
+24904,Xã Gia Lâm,676
+24907,Xã Tân Thanh,676
+24910,Xã Tân Văn,676
+24913,Xã Hoài Đức,676
+24916,Xã Tân Hà,676
+24919,Xã Liên Hà,676
+24922,Xã Đan Phượng,676
+24925,Xã Nam Hà,676
+24928,Thị trấn D'Ran,677
+24931,Thị trấn Thạnh Mỹ,677
+24934,Xã Lạc Xuân,677
+24937,Xã Đạ Ròn,677
+24940,Xã Lạc Lâm,677
+24943,Xã Ka Đô,677
+24946,Xã Quảng Lập,677
+24949,Xã Ka Đơn,677
+24952,Xã Tu Tra,677
+24955,Xã Pró,677
+24958,Thị trấn Liên Nghĩa,678
+24961,Xã Hiệp An,678
+24964,Xã Liên Hiệp,678
+24967,Xã Hiệp Thạnh,678
+24970,Xã Bình Thạnh,678
+24973,Xã N'Thol Hạ,678
+24976,Xã Tân Hội,678
+24979,Xã Tân Thành,678
+24982,Xã Phú Hội,678
+24985,Xã Ninh Gia,678
+24988,Xã Tà Năng,678
+24989,Xã Đa Quyn,678
+24991,Xã Tà Hine,678
+24994,Xã Đà Loan,678
+24997,Xã Ninh Loan,678
+25000,Thị trấn Di Linh,679
+25003,Xã Đinh Trang Thượng,679
+25006,Xã Tân Thượng,679
+25007,Xã Tân Lâm,679
+25009,Xã Tân Châu,679
+25012,Xã Tân Nghĩa,679
+25015,Xã Gia Hiệp,679
+25018,Xã Đinh Lạc,679
+25021,Xã Tam Bố,679
+25024,Xã Đinh Trang Hòa,679
+25027,Xã Liên Đầm,679
+25030,Xã Gung Ré,679
+25033,Xã Bảo Thuận,679
+25036,Xã Hòa Ninh,679
+25039,Xã Hòa Trung,679
+25042,Xã Hòa Nam,679
+25045,Xã Hòa Bắc,679
+25048,Xã Sơn Điền,679
+25051,Xã Gia Bắc,679
+25054,Thị trấn Lộc Thắng,680
+25057,Xã Lộc Bảo,680
+25060,Xã Lộc Lâm,680
+25063,Xã Lộc Phú,680
+25066,Xã Lộc Bắc,680
+25069,Xã B' Lá,680
+25072,Xã Lộc Ngãi,680
+25075,Xã Lộc Quảng,680
+25078,Xã Lộc Tân,680
+25081,Xã Lộc Đức,680
+25084,Xã Lộc An,680
+25087,Xã Tân Lạc,680
+25090,Xã Lộc Thành,680
+25093,Xã Lộc Nam,680
+25096,Thị trấn Đạ M'ri,681
+25099,Thị trấn Ma Đa Guôi,681
+25105,Xã Hà Lâm,681
+25108,Xã Đạ Tồn,681
+25111,Xã Đạ Oai,681
+25114,Xã Đạ Ploa,681
+25117,Xã Ma Đa Guôi,681
+25120,Xã Đoàn Kết,681
+25123,Xã Phước Lộc,681
+25126,Thị trấn Đạ Tẻh,682
+25129,Xã An Nhơn,682
+25132,Xã Quốc Oai,682
+25135,Xã Mỹ Đức,682
+25138,Xã Quảng Trị,682
+25141,Xã Đạ Lây,682
+25147,Xã Triệu Hải,682
+25153,Xã Đạ Kho,682
+25156,Xã Đạ Pal,682
+25159,Thị trấn Cát Tiên,683
+25162,Xã Tiên Hoàng,683
+25165,Xã Phước Cát 2,683
+25168,Xã Gia Viễn,683
+25171,Xã Nam Ninh,683
+25180,Thị trấn Phước Cát ,683
+25183,Xã Đức Phổ,683
+25189,Xã Quảng Ngãi,683
+25192,Xã Đồng Nai Thượng,683
+25216,Phường Thác Mơ,688
+25217,Phường Long Thủy,688
+25219,Phường Phước Bình,688
+25220,Phường Long Phước,688
+25237,Phường Sơn Giang,688
+25245,Xã Long Giang,688
+25249,Xã Phước Tín,688
+25195,Phường Tân Phú,689
+25198,Phường Tân Đồng,689
+25201,Phường Tân Bình,689
+25204,Phường Tân Xuân,689
+25205,Phường Tân Thiện,689
+25207,Xã Tân Thành,689
+25210,Phường Tiến Thành,689
+25213,Xã Tiến Hưng,689
+25320,Phường Hưng Chiến,690
+25324,Phường An Lộc,690
+25325,Phường Phú Thịnh,690
+25326,Phường Phú Đức,690
+25333,Xã Thanh Lương,690
+25336,Xã Thanh Phú,690
+25222,Xã Bù Gia Mập,691
+25225,Xã Đak Ơ,691
+25228,Xã Đức Hạnh,691
+25229,Xã Phú Văn,691
+25231,Xã Đa Kia,691
+25232,Xã Phước Minh,691
+25234,Xã Bình Thắng,691
+25267,Xã Phú Nghĩa,691
+25270,Thị trấn Lộc Ninh,692
+25273,Xã Lộc Hòa,692
+25276,Xã Lộc An,692
+25279,Xã Lộc Tấn,692
+25280,Xã Lộc Thạnh,692
+25282,Xã Lộc Hiệp,692
+25285,Xã Lộc Thiện,692
+25288,Xã Lộc Thuận,692
+25291,Xã Lộc Quang,692
+25292,Xã Lộc Phú,692
+25294,Xã Lộc Thành,692
+25297,Xã Lộc Thái,692
+25300,Xã Lộc Điền,692
+25303,Xã Lộc Hưng,692
+25305,Xã Lộc Thịnh,692
+25306,Xã Lộc Khánh,692
+25308,Thị trấn Thanh Bình,693
+25309,Xã Hưng Phước,693
+25310,Xã Phước Thiện,693
+25312,Xã Thiện Hưng,693
+25315,Xã Thanh Hòa,693
+25318,Xã Tân Thành,693
+25321,Xã Tân Tiến,693
+25327,Xã Thanh An,694
+25330,Xã An Khương,694
+25339,Xã An Phú,694
+25342,Xã Tân Lợi,694
+25345,Xã Tân Hưng,694
+25348,Xã Minh Đức,694
+25349,Xã Minh Tâm,694
+25351,Xã Phước An,694
+25354,Xã Thanh Bình,694
+25357,Thị trấn Tân Khai,694
+25360,Xã Đồng Nơ,694
+25361,Xã Tân Hiệp,694
+25438,Xã Tân Quan,694
+25363,Thị trấn Tân Phú,695
+25366,Xã Thuận Lợi,695
+25369,Xã Đồng Tâm,695
+25372,Xã Tân Phước,695
+25375,Xã Tân Hưng,695
+25378,Xã Tân Lợi,695
+25381,Xã Tân Lập,695
+25384,Xã Tân Hòa,695
+25387,Xã Thuận Phú,695
+25390,Xã Đồng Tiến,695
+25393,Xã Tân Tiến,695
+25396,Thị trấn Đức Phong,696
+25398,Xã Đường 10,696
+25399,Xã Đak Nhau,696
+25400,Xã Phú Sơn,696
+25402,Xã Thọ Sơn,696
+25404,Xã Bình Minh,696
+25405,Xã Bom Bo,696
+25408,Xã Minh Hưng,696
+25411,Xã Đoàn Kết,696
+25414,Xã Đồng Nai,696
+25417,Xã Đức Liễu,696
+25420,Xã Thống Nhất,696
+25423,Xã Nghĩa Trung,696
+25424,Xã Nghĩa Bình,696
+25426,Xã Đăng Hà,696
+25429,Xã Phước Sơn,696
+25432,Thị trấn Chơn Thành,697
+25433,Xã Thành Tâm,697
+25435,Xã Minh Lập,697
+25439,Xã Quang Minh,697
+25441,Xã Minh Hưng,697
+25444,Xã Minh Long,697
+25447,Xã Minh Thành,697
+25450,Xã Nha Bích,697
+25453,Xã Minh Thắng,697
+25240,Xã Long Bình,698
+25243,Xã Bình Tân,698
+25244,Xã Bình Sơn,698
+25246,Xã Long Hưng,698
+25250,Xã Phước Tân,698
+25252,Xã Bù Nho,698
+25255,Xã Long Hà,698
+25258,Xã Long Tân,698
+25261,Xã Phú Trung,698
+25264,Xã Phú Riềng,698
+25456,Phường 1,703
+25459,Phường 3,703
+25462,Phường 4,703
+25465,Phường Hiệp Ninh,703
+25468,Phường 2,703
+25471,Xã Thạnh Tân,703
+25474,Xã Tân Bình,703
+25477,Xã Bình Minh,703
+25480,Phường Ninh Sơn,703
+25483,Phường Ninh Thạnh,703
+25486,Thị trấn Tân Biên,705
+25489,Xã Tân Lập,705
+25492,Xã Thạnh Bắc,705
+25495,Xã Tân Bình,705
+25498,Xã Thạnh Bình,705
+25501,Xã Thạnh Tây,705
+25504,Xã Hòa Hiệp,705
+25507,Xã Tân Phong,705
+25510,Xã Mỏ Công,705
+25513,Xã Trà Vong,705
+25516,Thị trấn Tân Châu,706
+25519,Xã Tân Hà,706
+25522,Xã Tân Đông,706
+25525,Xã Tân Hội,706
+25528,Xã Tân Hòa,706
+25531,Xã Suối Ngô,706
+25534,Xã Suối Dây,706
+25537,Xã Tân Hiệp,706
+25540,Xã Thạnh Đông,706
+25543,Xã Tân Thành,706
+25546,Xã Tân Phú,706
+25549,Xã Tân Hưng,706
+25552,Thị trấn Dương Minh Châu,707
+25555,Xã Suối Đá,707
+25558,Xã Phan,707
+25561,Xã Phước Ninh,707
+25564,Xã Phước Minh,707
+25567,Xã Bàu Năng,707
+25570,Xã Chà Là,707
+25573,Xã Cầu Khởi,707
+25576,Xã Bến Củi,707
+25579,Xã Lộc Ninh,707
+25582,Xã Truông Mít,707
+25585,Thị trấn Châu Thành,708
+25588,Xã Hảo Đước,708
+25591,Xã Phước Vinh,708
+25594,Xã Đồng Khởi,708
+25597,Xã Thái Bình,708
+25600,Xã An Cơ,708
+25603,Xã Biên Giới,708
+25606,Xã Hòa Thạnh,708
+25609,Xã Trí Bình,708
+25612,Xã Hòa Hội,708
+25615,Xã An Bình,708
+25618,Xã Thanh Điền,708
+25621,Xã Thành Long,708
+25624,Xã Ninh Điền,708
+25627,Xã Long Vĩnh,708
+25630,Phường Long Hoa,709
+25633,Phường Hiệp Tân,709
+25636,Phường Long Thành Bắc,709
+25639,Xã Trường Hòa,709
+25642,Xã Trường Đông,709
+25645,Phường Long Thành Trung,709
+25648,Xã Trường Tây,709
+25651,Xã Long Thành Nam,709
+25654,Thị trấn Gò Dầu,710
+25657,Xã Thạnh Đức,710
+25660,Xã Cẩm Giang,710
+25663,Xã Hiệp Thạnh,710
+25666,Xã Bàu Đồn,710
+25669,Xã Phước Thạnh,710
+25672,Xã Phước Đông,710
+25675,Xã Phước Trạch,710
+25678,Xã Thanh Phước,710
+25681,Thị trấn Bến Cầu,711
+25684,Xã Long Chữ,711
+25687,Xã Long Phước,711
+25690,Xã Long Giang,711
+25693,Xã Tiên Thuận,711
+25696,Xã Long Khánh,711
+25699,Xã Lợi Thuận,711
+25702,Xã Long Thuận,711
+25705,Xã An Thạnh,711
+25708,Phường Trảng Bàng,712
+25711,Xã Đôn Thuận,712
+25714,Xã Hưng Thuận,712
+25717,Phường Lộc Hưng,712
+25720,Phường Gia Lộc,712
+25723,Phường Gia Bình,712
+25729,Xã Phước Bình,712
+25732,Phường An Tịnh,712
+25735,Phường An Hòa,712
+25738,Xã Phước Chỉ,712
+25741,Phường Hiệp Thành,718
+25744,Phường Phú Lợi,718
+25747,Phường Phú Cường,718
+25750,Phường Phú Hòa,718
+25753,Phường Phú Thọ,718
+25756,Phường Chánh Nghĩa,718
+25759,Phường Định Hoà,718
+25760,Phường Hoà Phú,718
+25762,Phường Phú Mỹ,718
+25763,Phường Phú Tân,718
+25765,Phường Tân An,718
+25768,Phường Hiệp An,718
+25771,Phường Tương Bình Hiệp,718
+25774,Phường Chánh Mỹ,718
+25816,Xã Trừ Văn Thố,719
+25819,Xã Cây Trường II,719
+25822,Thị trấn Lai Uyên,719
+25825,Xã Tân Hưng,719
+25828,Xã Long Nguyên,719
+25831,Xã Hưng Hòa,719
+25834,Xã Lai Hưng,719
+25777,Thị trấn Dầu Tiếng,720
+25780,Xã Minh Hoà,720
+25783,Xã Minh Thạnh,720
+25786,Xã Minh Tân,720
+25789,Xã Định An,720
+25792,Xã Long Hoà,720
+25795,Xã Định Thành,720
+25798,Xã Định Hiệp,720
+25801,Xã An Lập,720
+25804,Xã Long Tân,720
+25807,Xã Thanh An,720
+25810,Xã Thanh Tuyền,720
+25813,Phường Mỹ Phước,721
+25837,Phường Chánh Phú Hòa,721
+25840,Xã An Điền,721
+25843,Xã An Tây,721
+25846,Phường Thới Hòa,721
+25849,Phường Hòa Lợi,721
+25852,Phường Tân Định,721
+25855,Xã Phú An,721
+25858,Thị trấn Phước Vĩnh,722
+25861,Xã An Linh,722
+25864,Xã Phước Sang,722
+25865,Xã An Thái,722
+25867,Xã An Long,722
+25870,Xã An Bình,722
+25873,Xã Tân Hiệp,722
+25876,Xã Tam Lập,722
+25879,Xã Tân Long,722
+25882,Xã Vĩnh Hoà,722
+25885,Xã Phước Hoà,722
+25888,Phường Uyên Hưng,723
+25891,Phường Tân Phước Khánh,723
+25912,Phường Vĩnh Tân,723
+25915,Phường Hội Nghĩa,723
+25920,Phường Tân Hiệp,723
+25921,Phường Khánh Bình,723
+25924,Phường Phú Chánh,723
+25930,Xã Bạch Đằng,723
+25933,Phường Tân Vĩnh Hiệp,723
+25936,Phường Thạnh Phước,723
+25937,Xã Thạnh Hội,723
+25939,Phường Thái Hòa,723
+25942,Phường Dĩ An,724
+25945,Phường Tân Bình,724
+25948,Phường Tân Đông Hiệp,724
+25951,Phường Bình An,724
+25954,Phường Bình Thắng,724
+25957,Phường Đông Hòa,724
+25960,Phường An Bình,724
+25963,Phường An Thạnh,725
+25966,Phường Lái Thiêu,725
+25969,Phường Bình Chuẩn,725
+25972,Phường Thuận Giao,725
+25975,Phường An Phú,725
+25978,Phường Hưng Định,725
+25981,Xã An Sơn,725
+25984,Phường Bình Nhâm,725
+25987,Phường Bình Hòa,725
+25990,Phường Vĩnh Phú,725
+25894,Xã Tân Định,726
+25897,Xã Bình Mỹ,726
+25900,Thị trấn Tân Bình,726
+25903,Xã Tân Lập,726
+25906,Thị trấn Tân Thành,726
+25907,Xã Đất Cuốc,726
+25908,Xã Hiếu Liêm,726
+25909,Xã Lạc An,726
+25918,Xã Tân Mỹ,726
+25927,Xã Thường Tân,726
+25993,Phường Trảng Dài,731
+25996,Phường Tân Phong,731
+25999,Phường Tân Biên,731
+26002,Phường Hố Nai,731
+26005,Phường Tân Hòa,731
+26008,Phường Tân Hiệp,731
+26011,Phường Bửu Long,731
+26014,Phường Tân Tiến,731
+26017,Phường Tam Hiệp,731
+26020,Phường Long Bình,731
+26023,Phường Quang Vinh,731
+26026,Phường Tân Mai,731
+26029,Phường Thống Nhất,731
+26032,Phường Trung Dũng,731
+26035,Phường Tam Hòa,731
+26038,Phường Hòa Bình,731
+26041,Phường Quyết Thắng,731
+26044,Phường Thanh Bình,731
+26047,Phường Bình Đa,731
+26050,Phường An Bình,731
+26053,Phường Bửu Hòa,731
+26056,Phường Long Bình Tân,731
+26059,Phường Tân Vạn,731
+26062,Phường Tân Hạnh,731
+26065,Phường Hiệp Hòa,731
+26068,Phường Hóa An,731
+26371,Phường An Hòa,731
+26374,Phường Tam Phước,731
+26377,Phường Phước Tân,731
+26380,Xã Long Hưng,731
+26071,Phường Xuân Trung,732
+26074,Phường Xuân Thanh,732
+26077,Phường Xuân Bình,732
+26080,Phường Xuân An,732
+26083,Phường Xuân Hoà,732
+26086,Phường Phú Bình,732
+26089,Xã Bình Lộc,732
+26092,Xã Bảo Quang,732
+26095,Phường Suối Tre,732
+26098,Phường Bảo Vinh,732
+26101,Phường Xuân Lập,732
+26104,Phường Bàu Sen,732
+26107,Xã Bàu Trâm,732
+26110,Phường Xuân Tân,732
+26113,Xã Hàng Gòn,732
+26116,Thị trấn Tân Phú,734
+26119,Xã Dak Lua,734
+26122,Xã Nam Cát Tiên,734
+26125,Xã Phú An,734
+26128,Xã Núi Tượng,734
+26131,Xã Tà Lài,734
+26134,Xã Phú Lập,734
+26137,Xã Phú Sơn,734
+26140,Xã Phú Thịnh,734
+26143,Xã Thanh Sơn,734
+26146,Xã Phú Trung,734
+26149,Xã Phú Xuân,734
+26152,Xã Phú Lộc,734
+26155,Xã Phú Lâm,734
+26158,Xã Phú Bình,734
+26161,Xã Phú Thanh,734
+26164,Xã Trà Cổ,734
+26167,Xã Phú Điền,734
+26170,Thị trấn Vĩnh An,735
+26173,Xã Phú Lý,735
+26176,Xã Trị An,735
+26179,Xã Tân An,735
+26182,Xã Vĩnh Tân,735
+26185,Xã Bình Lợi,735
+26188,Xã Thạnh Phú,735
+26191,Xã Thiện Tân,735
+26194,Xã Tân Bình,735
+26197,Xã Bình Hòa,735
+26200,Xã Mã Đà,735
+26203,Xã Hiếu Liêm,735
+26206,Thị trấn Định Quán,736
+26209,Xã Thanh Sơn,736
+26212,Xã Phú Tân,736
+26215,Xã Phú Vinh,736
+26218,Xã Phú Lợi,736
+26221,Xã Phú Hòa,736
+26224,Xã Ngọc Định,736
+26227,Xã La Ngà,736
+26230,Xã Gia Canh,736
+26233,Xã Phú Ngọc,736
+26236,Xã Phú Cường,736
+26239,Xã Túc Trưng,736
+26242,Xã Phú Túc,736
+26245,Xã Suối Nho,736
+26248,Thị trấn Trảng Bom,737
+26251,Xã Thanh Bình,737
+26254,Xã Cây Gáo,737
+26257,Xã Bàu Hàm,737
+26260,Xã Sông Thao,737
+26263,Xã Sông Trầu,737
+26266,Xã Đông Hoà,737
+26269,Xã Bắc Sơn,737
+26272,Xã Hố Nai 3,737
+26275,Xã Tây Hoà,737
+26278,Xã Bình Minh,737
+26281,Xã Trung Hoà,737
+26284,Xã Đồi 61,737
+26287,Xã Hưng Thịnh,737
+26290,Xã Quảng Tiến,737
+26293,Xã Giang Điền,737
+26296,Xã An Viễn,737
+26299,Xã Gia Tân 1,738
+26302,Xã Gia Tân 2,738
+26305,Xã Gia Tân 3,738
+26308,Xã Gia Kiệm,738
+26311,Xã Quang Trung,738
+26314,Xã Bàu Hàm 2,738
+26317,Xã Hưng Lộc,738
+26320,Xã Lộ 25,738
+26323,Xã Xuân Thiện,738
+26326,Thị trấn Dầu Giây,738
+26329,Xã Sông Nhạn,739
+26332,Xã Xuân Quế,739
+26335,Xã Nhân Nghĩa,739
+26338,Xã Xuân Đường,739
+26341,Thị trấn Long Giao,739
+26344,Xã Xuân Mỹ,739
+26347,Xã Thừa Đức,739
+26350,Xã Bảo Bình,739
+26353,Xã Xuân Bảo,739
+26356,Xã Xuân Tây,739
+26359,Xã Xuân Đông,739
+26362,Xã Sông Ray,739
+26365,Xã Lâm San,739
+26368,Thị trấn Long Thành,740
+26383,Xã An Phước,740
+26386,Xã Bình An,740
+26389,Xã Long Đức,740
+26392,Xã Lộc An,740
+26395,Xã Bình Sơn,740
+26398,Xã Tam An,740
+26401,Xã Cẩm Đường,740
+26404,Xã Long An,740
+26410,Xã Bàu Cạn,740
+26413,Xã Long Phước,740
+26416,Xã Phước Bình,740
+26419,Xã Tân Hiệp,740
+26422,Xã Phước Thái,740
+26425,Thị trấn Gia Ray,741
+26428,Xã Xuân Bắc,741
+26431,Xã Suối Cao,741
+26434,Xã Xuân Thành,741
+26437,Xã Xuân Thọ,741
+26440,Xã Xuân Trường,741
+26443,Xã Xuân Hòa,741
+26446,Xã Xuân Hưng,741
+26449,Xã Xuân Tâm,741
+26452,Xã Suối Cát,741
+26455,Xã Xuân Hiệp,741
+26458,Xã Xuân Phú,741
+26461,Xã Xuân Định,741
+26464,Xã Bảo Hoà,741
+26467,Xã Lang Minh,741
+26470,Xã Phước Thiền,742
+26473,Xã Long Tân,742
+26476,Xã Đại Phước,742
+26479,Thị trấn Hiệp Phước,742
+26482,Xã Phú Hữu,742
+26485,Xã Phú Hội,742
+26488,Xã Phú Thạnh,742
+26491,Xã Phú Đông,742
+26494,Xã Long Thọ,742
+26497,Xã Vĩnh Thanh,742
+26500,Xã Phước Khánh,742
+26503,Xã Phước An,742
+26506,Phường 1,747
+26508,Phường Thắng Tam,747
+26509,Phường 2,747
+26512,Phường 3,747
+26515,Phường 4,747
+26518,Phường 5,747
+26521,Phường Thắng Nhì,747
+26524,Phường 7,747
+26526,Phường Nguyễn An Ninh,747
+26527,Phường 8,747
+26530,Phường 9,747
+26533,Phường Thắng Nhất,747
+26535,Phường Rạch Dừa,747
+26536,Phường 10,747
+26539,Phường 11,747
+26542,Phường 12,747
+26545,Xã Long Sơn,747
+26548,Phường Phước Hưng,748
+26551,Phường Phước Hiệp,748
+26554,Phường Phước Nguyên,748
+26557,Phường Long Toàn,748
+26558,Phường Long Tâm,748
+26560,Phường Phước Trung,748
+26563,Phường Long Hương,748
+26566,Phường Kim Dinh,748
+26567,Xã Tân Hưng,748
+26569,Xã Long Phước,748
+26572,Xã Hoà Long,748
+26574,Xã Bàu Chinh,750
+26575,Thị trấn Ngãi Giao,750
+26578,Xã Bình Ba,750
+26581,Xã Suối Nghệ,750
+26584,Xã Xuân Sơn,750
+26587,Xã Sơn Bình,750
+26590,Xã Bình Giã,750
+26593,Xã Bình Trung,750
+26596,Xã Xà Bang,750
+26599,Xã Cù Bị,750
+26602,Xã Láng Lớn,750
+26605,Xã Quảng Thành,750
+26608,Xã Kim Long,750
+26611,Xã Suối Rao,750
+26614,Xã Đá Bạc,750
+26617,Xã Nghĩa Thành,750
+26620,Thị trấn Phước Bửu,751
+26623,Xã Phước Thuận,751
+26626,Xã Phước Tân,751
+26629,Xã Xuyên Mộc,751
+26632,Xã Bông Trang,751
+26635,Xã Tân Lâm,751
+26638,Xã Bàu Lâm,751
+26641,Xã Hòa Bình,751
+26644,Xã Hòa Hưng,751
+26647,Xã Hòa Hiệp,751
+26650,Xã Hòa Hội,751
+26653,Xã Bưng Riềng,751
+26656,Xã Bình Châu,751
+26659,Thị trấn Long Điền,752
+26662,Thị trấn Long Hải,752
+26665,Xã An Ngãi,752
+26668,Xã Tam Phước,752
+26671,Xã An Nhứt,752
+26674,Xã Phước Tỉnh,752
+26677,Xã Phước Hưng,752
+26680,Thị trấn Đất Đỏ,753
+26683,Xã Phước Long Thọ,753
+26686,Xã Phước Hội,753
+26689,Xã Long Mỹ,753
+26692,Thị trấn Phước Hải,753
+26695,Xã Long Tân,753
+26698,Xã Láng Dài,753
+26701,Xã Lộc An,753
+26704,Phường Phú Mỹ,754
+26707,Xã Tân Hoà,754
+26710,Xã Tân Hải,754
+26713,Phường Phước Hoà,754
+26716,Phường Tân Phước,754
+26719,Phường Mỹ Xuân,754
+26722,Xã Sông Xoài,754
+26725,Phường Hắc Dịch,754
+26728,Xã Châu Pha,754
+26731,Xã Tóc Tiên,754
+26734,Phường Tân Định,760
+26737,Phường Đa Kao,760
+26740,Phường Bến Nghé,760
+26743,Phường Bến Thành,760
+26746,Phường Nguyễn Thái Bình,760
+26749,Phường Phạm Ngũ Lão,760
+26752,Phường Cầu Ông Lãnh,760
+26755,Phường Cô Giang,760
+26758,Phường Nguyễn Cư Trinh,760
+26761,Phường Cầu Kho,760
+26764,Phường Thạnh Xuân,761
+26767,Phường Thạnh Lộc,761
+26770,Phường Hiệp Thành,761
+26773,Phường Thới An,761
+26776,Phường Tân Chánh Hiệp,761
+26779,Phường An Phú Đông,761
+26782,Phường Tân Thới Hiệp,761
+26785,Phường Trung Mỹ Tây,761
+26787,Phường Tân Hưng Thuận,761
+26788,Phường Đông Hưng Thuận,761
+26791,Phường Tân Thới Nhất,761
+26869,Phường 15,764
+26872,Phường 13,764
+26875,Phường 17,764
+26876,Phường 6,764
+26878,Phường 16,764
+26881,Phường 12,764
+26882,Phường 14,764
+26884,Phường 10,764
+26887,Phường 05,764
+26890,Phường 07,764
+26893,Phường 04,764
+26896,Phường 01,764
+26897,Phường 9,764
+26898,Phường 8,764
+26899,Phường 11,764
+26902,Phường 03,764
+26905,Phường 13,765
+26908,Phường 11,765
+26911,Phường 27,765
+26914,Phường 26,765
+26917,Phường 12,765
+26920,Phường 25,765
+26923,Phường 05,765
+26926,Phường 07,765
+26929,Phường 24,765
+26932,Phường 06,765
+26935,Phường 14,765
+26938,Phường 15,765
+26941,Phường 02,765
+26944,Phường 01,765
+26947,Phường 03,765
+26950,Phường 17,765
+26953,Phường 21,765
+26956,Phường 22,765
+26959,Phường 19,765
+26962,Phường 28,765
+26965,Phường 02,766
+26968,Phường 04,766
+26971,Phường 12,766
+26974,Phường 13,766
+26977,Phường 01,766
+26980,Phường 03,766
+26983,Phường 11,766
+26986,Phường 07,766
+26989,Phường 05,766
+26992,Phường 10,766
+26995,Phường 06,766
+26998,Phường 08,766
+27001,Phường 09,766
+27004,Phường 14,766
+27007,Phường 15,766
+27010,Phường Tân Sơn Nhì,767
+27013,Phường Tây Thạnh,767
+27016,Phường Sơn Kỳ,767
+27019,Phường Tân Quý,767
+27022,Phường Tân Thành,767
+27025,Phường Phú Thọ Hòa,767
+27028,Phường Phú Thạnh,767
+27031,Phường Phú Trung,767
+27034,Phường Hòa Thạnh,767
+27037,Phường Hiệp Tân,767
+27040,Phường Tân Thới Hòa,767
+27043,Phường 04,768
+27046,Phường 05,768
+27049,Phường 09,768
+27052,Phường 07,768
+27055,Phường 03,768
+27058,Phường 01,768
+27061,Phường 02,768
+27064,Phường 08,768
+27067,Phường 15,768
+27070,Phường 10,768
+27073,Phường 11,768
+27076,Phường 17,768
+27085,Phường 13,768
+26794,Phường Linh Xuân,769
+26797,Phường Bình Chiểu,769
+26800,Phường Linh Trung,769
+26803,Phường Tam Bình,769
+26806,Phường Tam Phú,769
+26809,Phường Hiệp Bình Phước,769
+26812,Phường Hiệp Bình Chánh,769
+26815,Phường Linh Chiểu,769
+26818,Phường Linh Tây,769
+26821,Phường Linh Đông,769
+26824,Phường Bình Thọ,769
+26827,Phường Trường Thọ,769
+26830,Phường Long Bình,769
+26833,Phường Long Thạnh Mỹ,769
+26836,Phường Tân Phú,769
+26839,Phường Hiệp Phú,769
+26842,Phường Tăng Nhơn Phú A,769
+26845,Phường Tăng Nhơn Phú B,769
+26848,Phường Phước Long B,769
+26851,Phường Phước Long A,769
+26854,Phường Trường Thạnh,769
+26857,Phường Long Phước,769
+26860,Phường Long Trường,769
+26863,Phường Phước Bình,769
+26866,Phường Phú Hữu,769
+27088,Phường Thảo Điền,769
+27091,Phường An Phú,769
+27094,Phường An Khánh,769
+27097,Phường Bình Trưng Đông,769
+27100,Phường Bình Trưng Tây,769
+27109,Phường Cát Lái,769
+27112,Phường Thạnh Mỹ Lợi,769
+27115,Phường An Lợi Đông,769
+27118,Phường Thủ Thiêm,769
+27127,Phường 14,770
+27130,Phường 12,770
+27133,Phường 11,770
+27136,Phường 13,770
+27139,Phường Võ Thị Sáu,770
+27142,Phường 09,770
+27145,Phường 10,770
+27148,Phường 04,770
+27151,Phường 05,770
+27154,Phường 03,770
+27157,Phường 02,770
+27160,Phường 01,770
+27163,Phường 15,771
+27166,Phường 13,771
+27169,Phường 14,771
+27172,Phường 12,771
+27175,Phường 11,771
+27178,Phường 10,771
+27181,Phường 09,771
+27184,Phường 01,771
+27187,Phường 08,771
+27190,Phường 02,771
+27193,Phường 04,771
+27196,Phường 07,771
+27199,Phường 05,771
+27202,Phường 06,771
+27208,Phường 15,772
+27211,Phường 05,772
+27214,Phường 14,772
+27217,Phường 11,772
+27220,Phường 03,772
+27223,Phường 10,772
+27226,Phường 13,772
+27229,Phường 08,772
+27232,Phường 09,772
+27235,Phường 12,772
+27238,Phường 07,772
+27241,Phường 06,772
+27244,Phường 04,772
+27247,Phường 01,772
+27250,Phường 02,772
+27253,Phường 16,772
+27259,Phường 13,773
+27262,Phường 09,773
+27265,Phường 06,773
+27268,Phường 08,773
+27271,Phường 10,773
+27277,Phường 18,773
+27280,Phường 14,773
+27283,Phường 04,773
+27286,Phường 03,773
+27289,Phường 16,773
+27292,Phường 02,773
+27295,Phường 15,773
+27298,Phường 01,773
+27301,Phường 04,774
+27304,Phường 09,774
+27307,Phường 03,774
+27310,Phường 12,774
+27313,Phường 02,774
+27316,Phường 08,774
+27322,Phường 07,774
+27325,Phường 01,774
+27328,Phường 11,774
+27331,Phường 14,774
+27334,Phường 05,774
+27337,Phường 06,774
+27340,Phường 10,774
+27343,Phường 13,774
+27346,Phường 14,775
+27349,Phường 13,775
+27352,Phường 09,775
+27355,Phường 06,775
+27358,Phường 12,775
+27361,Phường 05,775
+27364,Phường 11,775
+27367,Phường 02,775
+27370,Phường 01,775
+27373,Phường 04,775
+27376,Phường 08,775
+27379,Phường 03,775
+27382,Phường 07,775
+27385,Phường 10,775
+27388,Phường 08,776
+27391,Phường 02,776
+27394,Phường 01,776
+27397,Phường 03,776
+27400,Phường 11,776
+27403,Phường 09,776
+27406,Phường 10,776
+27409,Phường 04,776
+27412,Phường 13,776
+27415,Phường 12,776
+27418,Phường 05,776
+27421,Phường 14,776
+27424,Phường 06,776
+27427,Phường 15,776
+27430,Phường 16,776
+27433,Phường 07,776
+27436,Phường Bình Hưng Hòa,777
+27439,Phường Bình Hưng Hoà A,777
+27442,Phường Bình Hưng Hoà B,777
+27445,Phường Bình Trị Đông,777
+27448,Phường Bình Trị Đông A,777
+27451,Phường Bình Trị Đông B,777
+27454,Phường Tân Tạo,777
+27457,Phường Tân Tạo A,777
+27460,Phường  An Lạc,777
+27463,Phường An Lạc A,777
+27466,Phường Tân Thuận Đông,778
+27469,Phường Tân Thuận Tây,778
+27472,Phường Tân Kiểng,778
+27475,Phường Tân Hưng,778
+27478,Phường Bình Thuận,778
+27481,Phường Tân Quy,778
+27484,Phường Phú Thuận,778
+27487,Phường Tân Phú,778
+27490,Phường Tân Phong,778
+27493,Phường Phú Mỹ,778
+27496,Thị trấn Củ Chi,783
+27499,Xã Phú Mỹ Hưng,783
+27502,Xã An Phú,783
+27505,Xã Trung Lập Thượng,783
+27508,Xã An Nhơn Tây,783
+27511,Xã Nhuận Đức,783
+27514,Xã Phạm Văn Cội,783
+27517,Xã Phú Hòa Đông,783
+27520,Xã Trung Lập Hạ,783
+27523,Xã Trung An,783
+27526,Xã Phước Thạnh,783
+27529,Xã Phước Hiệp,783
+27532,Xã Tân An Hội,783
+27535,Xã Phước Vĩnh An,783
+27538,Xã Thái Mỹ,783
+27541,Xã Tân Thạnh Tây,783
+27544,Xã Hòa Phú,783
+27547,Xã Tân Thạnh Đông,783
+27550,Xã Bình Mỹ,783
+27553,Xã Tân Phú Trung,783
+27556,Xã Tân Thông Hội,783
+27559,Thị trấn Hóc Môn,784
+27562,Xã Tân Hiệp,784
+27565,Xã Nhị Bình,784
+27568,Xã Đông Thạnh,784
+27571,Xã Tân Thới Nhì,784
+27574,Xã Thới Tam Thôn,784
+27577,Xã Xuân Thới Sơn,784
+27580,Xã Tân Xuân,784
+27583,Xã Xuân Thới Đông,784
+27586,Xã Trung Chánh,784
+27589,Xã Xuân Thới Thượng,784
+27592,Xã Bà Điểm,784
+27595,Thị trấn Tân Túc,785
+27598,Xã Phạm Văn Hai,785
+27601,Xã Vĩnh Lộc A,785
+27604,Xã Vĩnh Lộc B,785
+27607,Xã Bình Lợi,785
+27610,Xã Lê Minh Xuân,785
+27613,Xã Tân Nhựt,785
+27616,Xã Tân Kiên,785
+27619,Xã Bình Hưng,785
+27622,Xã Phong Phú,785
+27625,Xã An Phú Tây,785
+27628,Xã Hưng Long,785
+27631,Xã Đa Phước,785
+27634,Xã Tân Quý Tây,785
+27637,Xã Bình Chánh,785
+27640,Xã Quy Đức,785
+27643,Thị trấn Nhà Bè,786
+27646,Xã Phước Kiển,786
+27649,Xã Phước Lộc,786
+27652,Xã Nhơn Đức,786
+27655,Xã Phú Xuân,786
+27658,Xã Long Thới,786
+27661,Xã Hiệp Phước,786
+27664,Thị trấn Cần Thạnh,787
+27667,Xã Bình Khánh,787
+27670,Xã Tam Thôn Hiệp,787
+27673,Xã An Thới Đông,787
+27676,Xã Thạnh An,787
+27679,Xã Long Hòa,787
+27682,Xã Lý Nhơn,787
+27685,Phường 5,794
+27688,Phường 2,794
+27691,Phường 4,794
+27692,Phường Tân Khánh,794
+27694,Phường 1,794
+27697,Phường 3,794
+27698,Phường 7,794
+27700,Phường 6,794
+27703,Xã Hướng Thọ Phú,794
+27706,Xã Nhơn Thạnh Trung,794
+27709,Xã Lợi Bình Nhơn,794
+27712,Xã Bình Tâm,794
+27715,Phường Khánh Hậu,794
+27718,Xã An Vĩnh Ngãi,794
+27787,Phường 1,795
+27788,Phường 2,795
+27790,Xã Thạnh Trị,795
+27793,Xã Bình Hiệp,795
+27799,Xã Bình Tân,795
+27805,Xã Tuyên Thạnh,795
+27806,Phường 3,795
+27817,Xã Thạnh Hưng,795
+27721,Thị trấn Tân Hưng,796
+27724,Xã Hưng Hà,796
+27727,Xã Hưng Điền B,796
+27730,Xã Hưng Điền,796
+27733,Xã Thạnh Hưng,796
+27736,Xã Hưng Thạnh,796
+27739,Xã Vĩnh Thạnh,796
+27742,Xã Vĩnh Châu B,796
+27745,Xã Vĩnh Lợi,796
+27748,Xã Vĩnh Đại,796
+27751,Xã Vĩnh Châu A,796
+27754,Xã Vĩnh Bửu,796
+27757,Thị trấn Vĩnh Hưng,797
+27760,Xã Hưng Điền A,797
+27763,Xã Khánh Hưng,797
+27766,Xã Thái Trị,797
+27769,Xã Vĩnh Trị,797
+27772,Xã Thái Bình Trung,797
+27775,Xã Vĩnh Bình,797
+27778,Xã Vĩnh Thuận,797
+27781,Xã Tuyên Bình,797
+27784,Xã Tuyên Bình Tây,797
+27796,Xã Bình Hòa Tây,798
+27802,Xã Bình Thạnh,798
+27808,Xã Bình Hòa Trung,798
+27811,Xã Bình Hòa Đông,798
+27814,Thị trấn Bình Phong Thạnh,798
+27820,Xã Tân Lập,798
+27823,Xã Tân Thành,798
+27826,Thị trấn Tân Thạnh,799
+27829,Xã Bắc Hòa,799
+27832,Xã Hậu Thạnh Tây,799
+27835,Xã Nhơn Hòa Lập,799
+27838,Xã Tân Lập,799
+27841,Xã Hậu Thạnh Đông,799
+27844,Xã Nhơn Hoà,799
+27847,Xã Kiến Bình,799
+27850,Xã Tân Thành,799
+27853,Xã Tân Bình,799
+27856,Xã Tân Ninh,799
+27859,Xã Nhơn Ninh,799
+27862,Xã Tân Hòa,799
+27865,Thị trấn Thạnh Hóa,800
+27868,Xã Tân Hiệp,800
+27871,Xã Thuận Bình,800
+27874,Xã Thạnh Phước,800
+27877,Xã Thạnh Phú,800
+27880,Xã Thuận Nghĩa Hòa,800
+27883,Xã Thủy Đông,800
+27886,Xã Thủy Tây,800
+27889,Xã Tân Tây,800
+27892,Xã Tân Đông,800
+27895,Xã Thạnh An,800
+27898,Thị trấn Đông Thành,801
+27901,Xã Mỹ Quý Đông,801
+27904,Xã Mỹ Thạnh Bắc,801
+27907,Xã Mỹ Quý Tây,801
+27910,Xã Mỹ Thạnh Tây,801
+27913,Xã Mỹ Thạnh Đông,801
+27916,Xã Bình Thành,801
+27919,Xã Bình Hòa Bắc,801
+27922,Xã Bình Hòa Hưng,801
+27925,Xã Bình Hòa Nam,801
+27928,Xã Mỹ Bình,801
+27931,Thị trấn Hậu Nghĩa,802
+27934,Thị trấn Hiệp Hòa,802
+27937,Thị trấn Đức Hòa,802
+27940,Xã Lộc Giang,802
+27943,Xã An Ninh Đông,802
+27946,Xã An Ninh Tây,802
+27949,Xã Tân Mỹ,802
+27952,Xã Hiệp Hòa,802
+27955,Xã Đức Lập Thượng,802
+27958,Xã Đức Lập Hạ,802
+27961,Xã Tân Phú,802
+27964,Xã Mỹ Hạnh Bắc,802
+27967,Xã Đức Hòa Thượng,802
+27970,Xã Hòa Khánh Tây,802
+27973,Xã Hòa Khánh Đông,802
+27976,Xã Mỹ Hạnh Nam,802
+27979,Xã Hòa Khánh Nam,802
+27982,Xã Đức Hòa Đông,802
+27985,Xã Đức Hòa Hạ,802
+27988,Xã Hựu Thạnh,802
+27991,Thị trấn Bến Lức,803
+27994,Xã Thạnh Lợi,803
+27997,Xã Lương Bình,803
+28000,Xã Thạnh Hòa,803
+28003,Xã Lương Hòa,803
+28006,Xã Tân Hòa,803
+28009,Xã Tân Bửu,803
+28012,Xã An Thạnh,803
+28015,Xã Bình Đức,803
+28018,Xã Mỹ Yên,803
+28021,Xã Thanh Phú,803
+28024,Xã Long Hiệp,803
+28027,Xã Thạnh Đức,803
+28030,Xã Phước Lợi,803
+28033,Xã Nhựt Chánh,803
+28036,Thị trấn Thủ Thừa,804
+28039,Xã Long Thạnh,804
+28042,Xã Tân Thành,804
+28045,Xã Long Thuận,804
+28048,Xã Mỹ Lạc,804
+28051,Xã Mỹ Thạnh,804
+28054,Xã Bình An,804
+28057,Xã Nhị Thành,804
+28060,Xã Mỹ An,804
+28063,Xã Bình Thạnh,804
+28066,Xã Mỹ Phú,804
+28072,Xã Tân Long,804
+28075,Thị trấn Tân Trụ,805
+28078,Xã Tân Bình,805
+28084,Xã Quê Mỹ Thạnh,805
+28087,Xã Lạc Tấn,805
+28090,Xã Bình Trinh Đông,805
+28093,Xã Tân Phước Tây,805
+28096,Xã Bình Lãng,805
+28099,Xã Bình Tịnh,805
+28102,Xã Đức Tân,805
+28105,Xã Nhựt Ninh,805
+28108,Thị trấn Cần Đước,806
+28111,Xã Long Trạch,806
+28114,Xã Long Khê,806
+28117,Xã Long Định,806
+28120,Xã Phước Vân,806
+28123,Xã Long Hòa,806
+28126,Xã Long Cang,806
+28129,Xã Long Sơn,806
+28132,Xã Tân Trạch,806
+28135,Xã Mỹ Lệ,806
+28138,Xã Tân Lân,806
+28141,Xã Phước Tuy,806
+28144,Xã Long Hựu Đông,806
+28147,Xã Tân Ân,806
+28150,Xã Phước Đông,806
+28153,Xã Long Hựu Tây,806
+28156,Xã Tân Chánh,806
+28159,Thị trấn Cần Giuộc,807
+28162,Xã Phước Lý,807
+28165,Xã Long Thượng,807
+28168,Xã Long Hậu,807
+28174,Xã Phước Hậu,807
+28177,Xã Mỹ Lộc,807
+28180,Xã Phước Lại,807
+28183,Xã Phước Lâm,807
+28189,Xã Thuận Thành,807
+28192,Xã Phước Vĩnh Tây,807
+28195,Xã Phước Vĩnh Đông,807
+28198,Xã Long An,807
+28201,Xã Long Phụng,807
+28204,Xã Đông Thạnh,807
+28207,Xã Tân Tập,807
+28210,Thị trấn Tầm Vu,808
+28213,Xã Bình Quới,808
+28216,Xã Hòa Phú,808
+28219,Xã Phú Ngãi Trị,808
+28222,Xã Vĩnh Công,808
+28225,Xã Thuận Mỹ,808
+28228,Xã Hiệp Thạnh,808
+28231,Xã Phước Tân Hưng,808
+28234,Xã Thanh Phú Long,808
+28237,Xã Dương Xuân Hội,808
+28240,Xã An Lục Long,808
+28243,Xã Long Trì,808
+28246,Xã Thanh Vĩnh Đông,808
+28249,Phường 5,815
+28252,Phường 4,815
+28255,Phường 7,815
+28258,Phường 3,815
+28261,Phường 1,815
+28264,Phường 2,815
+28267,Phường 8,815
+28270,Phường 6,815
+28273,Phường 9,815
+28276,Phường 10,815
+28279,Phường Tân Long,815
+28282,Xã Đạo Thạnh,815
+28285,Xã Trung An,815
+28288,Xã Mỹ Phong,815
+28291,Xã Tân Mỹ Chánh,815
+28567,Xã Phước Thạnh,815
+28591,Xã Thới Sơn,815
+28294,Phường 3,816
+28297,Phường 2,816
+28300,Phường 4,816
+28303,Phường 1,816
+28306,Phường 5,816
+28309,Xã Long Hưng,816
+28312,Xã Long Thuận,816
+28315,Xã Long Chánh,816
+28318,Xã Long Hòa,816
+28708,Xã Bình Đông,816
+28717,Xã Bình Xuân,816
+28729,Xã Tân Trung,816
+28435,Phường 1,817
+28436,Phường 2,817
+28437,Phường 3,817
+28439,Phường 4,817
+28440,Phường 5,817
+28447,Xã Mỹ Phước Tây,817
+28450,Xã Mỹ Hạnh Đông,817
+28453,Xã Mỹ Hạnh Trung,817
+28459,Xã Tân Phú,817
+28462,Xã Tân Bình,817
+28468,Xã Tân Hội,817
+28474,Phường Nhị Mỹ,817
+28477,Xã Nhị Quý,817
+28480,Xã Thanh Hòa,817
+28483,Xã Phú Quý,817
+28486,Xã Long Khánh,817
+28321,Thị trấn Mỹ Phước,818
+28324,Xã Tân Hòa Đông,818
+28327,Xã Thạnh Tân,818
+28330,Xã Thạnh Mỹ,818
+28333,Xã Thạnh Hoà,818
+28336,Xã Phú Mỹ,818
+28339,Xã Tân Hòa Thành,818
+28342,Xã Hưng Thạnh,818
+28345,Xã Tân Lập 1,818
+28348,Xã Tân Hòa Tây,818
+28354,Xã Tân Lập 2,818
+28357,Xã Phước Lập,818
+28360,Thị trấn Cái Bè,819
+28363,Xã Hậu Mỹ Bắc B,819
+28366,Xã Hậu Mỹ Bắc A,819
+28369,Xã Mỹ Trung,819
+28372,Xã Hậu Mỹ Trinh,819
+28375,Xã Hậu Mỹ Phú,819
+28378,Xã Mỹ Tân,819
+28381,Xã Mỹ Lợi B,819
+28384,Xã Thiện Trung,819
+28387,Xã Mỹ Hội,819
+28390,Xã An Cư,819
+28393,Xã Hậu Thành,819
+28396,Xã Mỹ Lợi A,819
+28399,Xã Hòa Khánh,819
+28402,Xã Thiện Trí,819
+28405,Xã Mỹ Đức Đông,819
+28408,Xã Mỹ Đức Tây,819
+28411,Xã Đông Hòa Hiệp,819
+28414,Xã An Thái Đông,819
+28417,Xã Tân Hưng,819
+28420,Xã Mỹ Lương,819
+28423,Xã Tân Thanh,819
+28426,Xã An Thái Trung,819
+28429,Xã An Hữu,819
+28432,Xã Hòa Hưng,819
+28438,Xã Thạnh Lộc,820
+28441,Xã Mỹ Thành Bắc,820
+28444,Xã Phú Cường,820
+28456,Xã Mỹ Thành Nam,820
+28465,Xã Phú Nhuận,820
+28471,Xã Bình Phú,820
+28489,Xã Cẩm Sơn,820
+28492,Xã Phú An,820
+28495,Xã Mỹ Long,820
+28498,Xã Long Tiên,820
+28501,Xã Hiệp Đức,820
+28504,Xã Long Trung,820
+28507,Xã Hội Xuân,820
+28510,Xã Tân Phong,820
+28513,Xã Tam Bình,820
+28516,Xã Ngũ Hiệp,820
+28519,Thị trấn Tân Hiệp,821
+28522,Xã Tân Hội Đông,821
+28525,Xã Tân Hương,821
+28528,Xã Tân Lý Đông,821
+28531,Xã Tân Lý Tây,821
+28534,Xã Thân Cửu Nghĩa,821
+28537,Xã Tam Hiệp,821
+28540,Xã Điềm Hy,821
+28543,Xã Nhị Bình,821
+28546,Xã Dưỡng Điềm,821
+28549,Xã Đông Hòa,821
+28552,Xã Long Định,821
+28555,Xã Hữu Đạo,821
+28558,Xã Long An,821
+28561,Xã Long Hưng,821
+28564,Xã Bình Trưng,821
+28570,Xã Thạnh Phú,821
+28573,Xã Bàn Long,821
+28576,Xã Vĩnh Kim,821
+28579,Xã Bình Đức,821
+28582,Xã Song Thuận,821
+28585,Xã Kim Sơn,821
+28588,Xã Phú Phong,821
+28594,Thị trấn Chợ Gạo,822
+28597,Xã Trung Hòa,822
+28600,Xã Hòa Tịnh,822
+28603,Xã Mỹ Tịnh An,822
+28606,Xã Tân Bình Thạnh,822
+28609,Xã Phú Kiết,822
+28612,Xã Lương Hòa Lạc,822
+28615,Xã Thanh Bình,822
+28618,Xã Quơn Long,822
+28621,Xã Bình Phục Nhứt,822
+28624,Xã Đăng Hưng Phước,822
+28627,Xã Tân Thuận Bình,822
+28630,Xã Song Bình,822
+28633,Xã Bình Phan,822
+28636,Xã Long Bình Điền,822
+28639,Xã An Thạnh Thủy,822
+28642,Xã Xuân Đông,822
+28645,Xã Hòa Định,822
+28648,Xã Bình Ninh,822
+28651,Thị trấn Vĩnh Bình,823
+28654,Xã Đồng Sơn,823
+28657,Xã Bình Phú,823
+28660,Xã Đồng Thạnh,823
+28663,Xã Thành Công,823
+28666,Xã Bình Nhì,823
+28669,Xã Yên Luông,823
+28672,Xã Thạnh Trị,823
+28675,Xã Thạnh Nhựt,823
+28678,Xã Long Vĩnh,823
+28681,Xã Bình Tân,823
+28684,Xã Vĩnh Hựu,823
+28687,Xã Long Bình,823
+28702,Thị trấn Tân Hòa,824
+28705,Xã Tăng Hoà,824
+28711,Xã Tân Phước,824
+28714,Xã Gia Thuận,824
+28720,Thị trấn Vàm Láng,824
+28723,Xã Tân Tây,824
+28726,Xã Kiểng Phước,824
+28732,Xã Tân Đông,824
+28735,Xã Bình Ân,824
+28738,Xã Tân Điền,824
+28741,Xã Bình Nghị,824
+28744,Xã Phước Trung,824
+28747,Xã Tân Thành,824
+28690,Xã Tân Thới,825
+28693,Xã Tân Phú,825
+28696,Xã Phú Thạnh,825
+28699,Xã Tân Thạnh,825
+28750,Xã Phú Đông,825
+28753,Xã Phú Tân,825
+28756,Phường Phú Khương,829
+28757,Phường Phú Tân,829
+28759,Phường 8,829
+28762,Phường 6,829
+28765,Phường 4,829
+28768,Phường 5,829
+28777,Phường An Hội,829
+28780,Phường 7,829
+28783,Xã Sơn Đông,829
+28786,Xã Phú Hưng,829
+28789,Xã Bình Phú,829
+28792,Xã Mỹ Thạnh An,829
+28795,Xã Nhơn Thạnh,829
+28798,Xã Phú Nhuận,829
+28801,Thị trấn Châu Thành,831
+28804,Xã Tân Thạch,831
+28807,Xã Qưới Sơn,831
+28810,Xã An Khánh,831
+28813,Xã Giao Long,831
+28819,Xã Phú Túc,831
+28822,Xã Phú Đức,831
+28825,Xã Phú An Hòa,831
+28828,Xã An Phước,831
+28831,Xã Tam Phước,831
+28834,Xã Thành Triệu,831
+28837,Xã Tường Đa,831
+28840,Xã Tân Phú,831
+28843,Xã Quới Thành,831
+28846,Xã Phước Thạnh,831
+28849,Xã An Hóa,831
+28852,Xã Tiên Long,831
+28855,Xã An Hiệp,831
+28858,Xã Hữu Định,831
+28861,Xã Tiên Thủy,831
+28864,Xã Sơn Hòa,831
+28870,Thị trấn Chợ Lách,832
+28873,Xã Phú Phụng,832
+28876,Xã Sơn Định,832
+28879,Xã Vĩnh Bình,832
+28882,Xã Hòa Nghĩa,832
+28885,Xã Long Thới,832
+28888,Xã Phú Sơn,832
+28891,Xã Tân Thiềng,832
+28894,Xã Vĩnh Thành,832
+28897,Xã Vĩnh Hòa,832
+28900,Xã Hưng Khánh Trung B,832
+28903,Thị trấn Mỏ Cày,833
+28930,Xã Định Thủy,833
+28939,Xã Đa Phước Hội,833
+28940,Xã Tân Hội,833
+28942,Xã Phước Hiệp,833
+28945,Xã Bình Khánh ,833
+28951,Xã An Thạnh,833
+28957,Xã An Định,833
+28960,Xã Thành Thới B,833
+28963,Xã Tân Trung,833
+28966,Xã An Thới,833
+28969,Xã Thành Thới A,833
+28972,Xã Minh Đức,833
+28975,Xã Ngãi Đăng,833
+28978,Xã Cẩm Sơn,833
+28981,Xã Hương Mỹ,833
+28984,Thị trấn Giồng Trôm,834
+28987,Xã Phong Nẫm,834
+28993,Xã Mỹ Thạnh,834
+28996,Xã Châu Hòa,834
+28999,Xã Lương Hòa,834
+29002,Xã Lương Quới,834
+29005,Xã Lương Phú,834
+29008,Xã Châu Bình,834
+29011,Xã Thuận Điền,834
+29014,Xã Sơn Phú,834
+29017,Xã Bình Hoà,834
+29020,Xã Phước Long,834
+29023,Xã Hưng Phong,834
+29026,Xã Long Mỹ,834
+29029,Xã Tân Hào,834
+29032,Xã Bình Thành,834
+29035,Xã Tân Thanh,834
+29038,Xã Tân Lợi Thạnh,834
+29041,Xã Thạnh Phú Đông,834
+29044,Xã Hưng Nhượng,834
+29047,Xã Hưng Lễ,834
+29050,Thị trấn Bình Đại,835
+29053,Xã Tam Hiệp,835
+29056,Xã Long Định,835
+29059,Xã Long Hòa,835
+29062,Xã Phú Thuận,835
+29065,Xã Vang Quới Tây,835
+29068,Xã Vang Quới Đông,835
+29071,Xã Châu Hưng,835
+29074,Xã Phú Vang,835
+29077,Xã Lộc Thuận,835
+29080,Xã Định Trung,835
+29083,Xã Thới Lai,835
+29086,Xã Bình Thới,835
+29089,Xã Phú Long,835
+29092,Xã Bình Thắng,835
+29095,Xã Thạnh Trị,835
+29098,Xã Đại Hòa Lộc,835
+29101,Xã Thừa Đức,835
+29104,Xã Thạnh Phước,835
+29107,Xã Thới Thuận,835
+29110,Thị trấn Ba Tri,836
+29113,Xã Tân Mỹ,836
+29116,Xã Mỹ Hòa,836
+29119,Xã Tân Xuân,836
+29122,Xã Mỹ Chánh,836
+29125,Xã Bảo Thạnh,836
+29128,Xã An Phú Trung,836
+29131,Xã Mỹ Thạnh,836
+29134,Xã Mỹ Nhơn,836
+29137,Xã Phước Ngãi,836
+29143,Xã An Ngãi Trung,836
+29146,Xã Phú Lễ,836
+29149,Xã An Bình Tây,836
+29152,Xã Bảo Thuận,836
+29155,Xã Tân Hưng,836
+29158,Xã An Ngãi Tây,836
+29161,Xã An Hiệp,836
+29164,Xã Vĩnh Hòa,836
+29167,Xã Tân Thủy,836
+29170,Xã Vĩnh An,836
+29173,Xã An Đức,836
+29176,Xã An Hòa Tây,836
+29179,Xã An Thủy,836
+29182,Thị trấn Thạnh Phú,837
+29185,Xã Phú Khánh,837
+29188,Xã Đại Điền,837
+29191,Xã Quới Điền,837
+29194,Xã Tân Phong,837
+29197,Xã Mỹ Hưng,837
+29200,Xã An Thạnh,837
+29203,Xã Thới Thạnh,837
+29206,Xã Hòa Lợi,837
+29209,Xã An Điền,837
+29212,Xã Bình Thạnh,837
+29215,Xã An Thuận,837
+29218,Xã An Quy,837
+29221,Xã Thạnh Hải,837
+29224,Xã An Nhơn,837
+29227,Xã Giao Thạnh,837
+29230,Xã Thạnh Phong,837
+29233,Xã Mỹ An,837
+28889,Xã Phú Mỹ,838
+28901,Xã Hưng Khánh Trung A,838
+28906,Xã Thanh Tân,838
+28909,Xã Thạnh Ngãi,838
+28912,Xã Tân Phú Tây,838
+28915,Xã Phước Mỹ Trung,838
+28918,Xã Tân Thành Bình,838
+28921,Xã Thành An,838
+28924,Xã Hòa Lộc,838
+28927,Xã Tân Thanh Tây,838
+28933,Xã Tân Bình,838
+28936,Xã Nhuận Phú Tân,838
+28948,Xã Khánh Thạnh Tân,838
+29236,Phường 4,842
+29239,Phường 1,842
+29242,Phường 3,842
+29245,Phường 2,842
+29248,Phường 5,842
+29251,Phường 6,842
+29254,Phường 7,842
+29257,Phường 8,842
+29260,Phường 9,842
+29263,Xã Long Đức,842
+29266,Thị trấn Càng Long,844
+29269,Xã Mỹ Cẩm,844
+29272,Xã An Trường A,844
+29275,Xã An Trường,844
+29278,Xã Huyền Hội,844
+29281,Xã Tân An,844
+29284,Xã Tân Bình,844
+29287,Xã Bình Phú,844
+29290,Xã Phương Thạnh,844
+29293,Xã Đại Phúc,844
+29296,Xã Đại Phước,844
+29299,Xã Nhị Long Phú,844
+29302,Xã Nhị Long,844
+29305,Xã Đức Mỹ,844
+29308,Thị trấn Cầu Kè,845
+29311,Xã Hòa Ân,845
+29314,Xã Châu Điền,845
+29317,Xã An Phú Tân,845
+29320,Xã Hoà Tân,845
+29323,Xã Ninh Thới,845
+29326,Xã Phong Phú,845
+29329,Xã Phong Thạnh,845
+29332,Xã Tam Ngãi,845
+29335,Xã Thông Hòa,845
+29338,Xã Thạnh Phú,845
+29341,Thị trấn Tiểu Cần,846
+29344,Thị trấn Cầu Quan,846
+29347,Xã Phú Cần,846
+29350,Xã Hiếu Tử,846
+29353,Xã Hiếu Trung,846
+29356,Xã Long Thới,846
+29359,Xã Hùng Hòa,846
+29362,Xã Tân Hùng,846
+29365,Xã Tập Ngãi,846
+29368,Xã Ngãi Hùng,846
+29371,Xã Tân Hòa,846
+29374,Thị trấn Châu Thành,847
+29377,Xã Đa Lộc,847
+29380,Xã Mỹ Chánh,847
+29383,Xã Thanh Mỹ,847
+29386,Xã Lương Hoà A,847
+29389,Xã Lương Hòa,847
+29392,Xã Song Lộc,847
+29395,Xã Nguyệt Hóa,847
+29398,Xã Hòa Thuận,847
+29401,Xã Hòa Lợi,847
+29404,Xã Phước Hảo,847
+29407,Xã Hưng Mỹ,847
+29410,Xã Hòa Minh,847
+29413,Xã Long Hòa,847
+29416,Thị trấn Cầu Ngang,848
+29419,Thị trấn Mỹ Long,848
+29422,Xã Mỹ Long Bắc,848
+29425,Xã Mỹ Long Nam,848
+29428,Xã Mỹ Hòa,848
+29431,Xã Vĩnh Kim,848
+29434,Xã Kim Hòa,848
+29437,Xã Hiệp Hòa,848
+29440,Xã Thuận Hòa,848
+29443,Xã Long Sơn,848
+29446,Xã Nhị Trường,848
+29449,Xã Trường Thọ,848
+29452,Xã Hiệp Mỹ Đông,848
+29455,Xã Hiệp Mỹ Tây,848
+29458,Xã Thạnh Hòa Sơn,848
+29461,Thị trấn Trà Cú,849
+29462,Thị trấn Định An,849
+29464,Xã Phước Hưng,849
+29467,Xã Tập Sơn,849
+29470,Xã Tân Sơn,849
+29473,Xã An Quảng Hữu,849
+29476,Xã Lưu Nghiệp Anh,849
+29479,Xã Ngãi Xuyên,849
+29482,Xã Kim Sơn,849
+29485,Xã Thanh Sơn,849
+29488,Xã Hàm Giang,849
+29489,Xã Hàm Tân,849
+29491,Xã Đại An,849
+29494,Xã Định An,849
+29503,Xã Ngọc Biên,849
+29506,Xã Long Hiệp,849
+29509,Xã Tân Hiệp,849
+29497,Xã Đôn Xuân,850
+29500,Xã Đôn Châu,850
+29513,Thị trấn Long Thành,850
+29521,Xã Long Khánh,850
+29530,Xã Ngũ Lạc,850
+29533,Xã Long Vĩnh,850
+29536,Xã Đông Hải,850
+29512,Phường 1,851
+29515,Xã Long Toàn,851
+29516,Phường 2,851
+29518,Xã Long Hữu,851
+29524,Xã Dân Thành,851
+29527,Xã Trường Long Hòa,851
+29539,Xã Hiệp Thạnh,851
+29542,Phường 9,855
+29545,Phường 5,855
+29548,Phường 1,855
+29551,Phường 2,855
+29554,Phường 4,855
+29557,Phường 3,855
+29560,Phường 8,855
+29563,Phường Tân Ngãi,855
+29566,Phường Tân Hòa,855
+29569,Phường Tân Hội,855
+29572,Phường Trường An,855
+29575,Thị trấn Long Hồ,857
+29578,Xã Đồng Phú,857
+29581,Xã Bình Hòa Phước,857
+29584,Xã Hòa Ninh,857
+29587,Xã An Bình,857
+29590,Xã Thanh Đức,857
+29593,Xã Tân Hạnh,857
+29596,Xã Phước Hậu,857
+29599,Xã Long Phước,857
+29602,Xã Phú Đức,857
+29605,Xã Lộc Hòa,857
+29608,Xã Long An,857
+29611,Xã Phú Quới,857
+29614,Xã Thạnh Quới,857
+29617,Xã Hòa Phú,857
+29623,Xã Mỹ An,858
+29626,Xã Mỹ Phước,858
+29629,Xã An Phước,858
+29632,Xã Nhơn Phú,858
+29635,Xã Long Mỹ,858
+29638,Xã Hòa Tịnh,858
+29641,Thị trấn Cái Nhum,858
+29644,Xã Bình Phước,858
+29647,Xã Chánh An,858
+29650,Xã Tân An Hội,858
+29653,Xã Tân Long,858
+29656,Xã Tân Long Hội,858
+29659,Thị trấn Vũng Liêm,859
+29662,Xã Tân Quới Trung,859
+29665,Xã Quới Thiện,859
+29668,Xã Quới An,859
+29671,Xã Trung Chánh,859
+29674,Xã Tân An Luông,859
+29677,Xã Thanh Bình,859
+29680,Xã Trung Thành Tây,859
+29683,Xã Trung Hiệp,859
+29686,Xã Hiếu Phụng,859
+29689,Xã Trung Thành Đông,859
+29692,Xã Trung Thành,859
+29695,Xã Trung Hiếu,859
+29698,Xã Trung Ngãi,859
+29701,Xã Hiếu Thuận,859
+29704,Xã Trung Nghĩa,859
+29707,Xã Trung An,859
+29710,Xã Hiếu Nhơn,859
+29713,Xã Hiếu Thành,859
+29716,Xã Hiếu Nghĩa,859
+29719,Thị trấn Tam Bình,860
+29722,Xã Tân Lộc,860
+29725,Xã Phú Thịnh,860
+29728,Xã Hậu Lộc,860
+29731,Xã Hòa Thạnh,860
+29734,Xã Hoà Lộc,860
+29737,Xã Phú Lộc,860
+29740,Xã Song Phú,860
+29743,Xã Hòa Hiệp,860
+29746,Xã Mỹ Lộc,860
+29749,Xã Tân Phú,860
+29752,Xã Long Phú,860
+29755,Xã Mỹ Thạnh Trung,860
+29758,Xã Tường Lộc,860
+29761,Xã Loan Mỹ,860
+29764,Xã Ngãi Tứ,860
+29767,Xã Bình Ninh,860
+29770,Phường Cái Vồn,861
+29771,Phường Thành Phước,861
+29806,Xã Thuận An,861
+29809,Xã Đông Thạnh,861
+29812,Xã Đông Bình,861
+29813,Phường Đông Thuận,861
+29815,Xã Mỹ Hòa,861
+29818,Xã Đông Thành,861
+29821,Thị trấn Trà Ôn,862
+29824,Xã Xuân Hiệp,862
+29827,Xã Nhơn Bình,862
+29830,Xã Hòa Bình,862
+29833,Xã Thới Hòa,862
+29836,Xã Trà Côn,862
+29839,Xã Tân Mỹ,862
+29842,Xã Hựu Thành,862
+29845,Xã Vĩnh Xuân,862
+29848,Xã Thuận Thới,862
+29851,Xã Phú Thành,862
+29854,Xã Thiện Mỹ,862
+29857,Xã Lục Sỹ Thành,862
+29860,Xã Tích Thiện,862
+29773,Xã Tân Hưng,863
+29776,Xã Tân Thành,863
+29779,Xã Thành Trung,863
+29782,Xã Tân An Thạnh,863
+29785,Xã Tân Lược,863
+29788,Xã Nguyễn Văn Thảnh,863
+29791,Xã Thành Lợi,863
+29794,Xã Mỹ Thuận,863
+29797,Xã Tân Bình,863
+29800,Thị trấn Tân Quới,863
+29863,Phường 11,866
+29866,Phường 1,866
+29869,Phường 2,866
+29872,Phường 4,866
+29875,Phường 3,866
+29878,Phường 6,866
+29881,Xã Mỹ Ngãi,866
+29884,Xã Mỹ Tân,866
+29887,Xã Mỹ Trà,866
+29888,Phường Mỹ Phú,866
+29890,Xã Tân Thuận Tây,866
+29892,Phường Hoà Thuận,866
+29893,Xã Hòa An,866
+29896,Xã Tân Thuận Đông,866
+29899,Xã Tịnh Thới,866
+29902,Phường 3,867
+29905,Phường 1,867
+29908,Phường 4,867
+29911,Phường 2,867
+29914,Xã Tân Khánh Đông,867
+29917,Phường Tân Quy Đông,867
+29919,Phường An Hoà,867
+29920,Xã Tân Quy Tây,867
+29923,Xã Tân Phú Đông,867
+29954,Phường An Lộc,868
+29955,Phường An Thạnh,868
+29959,Xã Bình Thạnh,868
+29965,Xã Tân Hội,868
+29978,Phường An Lạc,868
+29986,Phường An Bình B,868
+29989,Phường An Bình A,868
+29926,Thị trấn Sa Rài,869
+29929,Xã Tân Hộ Cơ,869
+29932,Xã Thông Bình,869
+29935,Xã Bình Phú,869
+29938,Xã Tân Thành A,869
+29941,Xã Tân Thành B,869
+29944,Xã Tân Phước,869
+29947,Xã Tân Công Chí,869
+29950,Xã An Phước,869
+29956,Xã Thường Phước 1,870
+29962,Xã Thường Thới Hậu A,870
+29971,Thị trấn Thường Thới Tiền,870
+29974,Xã Thường Phước 2,870
+29977,Xã Thường Lạc,870
+29980,Xã Long Khánh A,870
+29983,Xã Long Khánh B,870
+29992,Xã Long Thuận,870
+29995,Xã Phú Thuận B,870
+29998,Xã Phú Thuận A,870
+30001,Thị trấn Tràm Chim,871
+30004,Xã Hoà Bình,871
+30007,Xã Tân Công Sính,871
+30010,Xã Phú Hiệp,871
+30013,Xã Phú Đức,871
+30016,Xã Phú Thành B,871
+30019,Xã An Hòa,871
+30022,Xã An Long,871
+30025,Xã Phú Cường,871
+30028,Xã Phú Ninh,871
+30031,Xã Phú Thọ,871
+30034,Xã Phú Thành A,871
+30037,Thị trấn Mỹ An,872
+30040,Xã Thạnh Lợi,872
+30043,Xã Hưng Thạnh,872
+30046,Xã Trường Xuân,872
+30049,Xã Tân Kiều,872
+30052,Xã Mỹ Hòa,872
+30055,Xã Mỹ Quý,872
+30058,Xã Mỹ Đông,872
+30061,Xã Đốc Binh Kiều,872
+30064,Xã Mỹ An,872
+30067,Xã Phú Điền,872
+30070,Xã Láng Biển,872
+30073,Xã Thanh Mỹ,872
+30076,Thị trấn Mỹ Thọ,873
+30079,Xã Gáo Giồng,873
+30082,Xã Phương Thịnh,873
+30085,Xã Ba Sao,873
+30088,Xã Phong Mỹ,873
+30091,Xã Tân Nghĩa,873
+30094,Xã Phương Trà,873
+30097,Xã Nhị Mỹ,873
+30100,Xã Mỹ Thọ,873
+30103,Xã Tân Hội Trung,873
+30106,Xã An Bình,873
+30109,Xã Mỹ Hội,873
+30112,Xã Mỹ Hiệp,873
+30115,Xã Mỹ Long,873
+30118,Xã Bình Hàng Trung,873
+30121,Xã Mỹ Xương,873
+30124,Xã Bình Hàng Tây,873
+30127,Xã Bình Thạnh,873
+30130,Thị trấn Thanh Bình,874
+30133,Xã Tân Quới,874
+30136,Xã Tân Hòa,874
+30139,Xã An Phong,874
+30142,Xã Phú Lợi,874
+30145,Xã Tân Mỹ,874
+30148,Xã Bình Tấn,874
+30151,Xã Tân Huề,874
+30154,Xã Tân Bình,874
+30157,Xã Tân Thạnh,874
+30160,Xã Tân Phú,874
+30163,Xã Bình Thành,874
+30166,Xã Tân Long,874
+30169,Thị trấn Lấp Vò,875
+30172,Xã Mỹ An Hưng A,875
+30175,Xã Tân Mỹ,875
+30178,Xã Mỹ An Hưng B,875
+30181,Xã Tân  Khánh Trung,875
+30184,Xã Long Hưng A,875
+30187,Xã Vĩnh Thạnh,875
+30190,Xã Long Hưng B,875
+30193,Xã Bình Thành,875
+30196,Xã Định An,875
+30199,Xã Định Yên,875
+30202,Xã Hội An Đông,875
+30205,Xã Bình Thạnh Trung,875
+30208,Thị trấn Lai Vung,876
+30211,Xã Tân Dương,876
+30214,Xã Hòa Thành,876
+30217,Xã Long Hậu,876
+30220,Xã Tân Phước,876
+30223,Xã Hòa Long,876
+30226,Xã Tân Thành,876
+30229,Xã Long Thắng,876
+30232,Xã Vĩnh Thới,876
+30235,Xã Tân Hòa,876
+30238,Xã Định Hòa,876
+30241,Xã Phong Hòa,876
+30244,Thị trấn Cái Tàu Hạ,877
+30247,Xã An Hiệp,877
+30250,Xã An Nhơn,877
+30253,Xã Tân Nhuận Đông,877
+30256,Xã Tân Bình,877
+30259,Xã Tân Phú Trung,877
+30262,Xã Phú Long,877
+30265,Xã An Phú Thuận,877
+30268,Xã Phú Hựu,877
+30271,Xã An Khánh,877
+30274,Xã Tân Phú,877
+30277,Xã Hòa Tân,877
+30280,Phường Mỹ Bình,883
+30283,Phường Mỹ Long,883
+30285,Phường Đông Xuyên,883
+30286,Phường Mỹ Xuyên,883
+30289,Phường Bình Đức,883
+30292,Phường Bình Khánh,883
+30295,Phường Mỹ Phước,883
+30298,Phường Mỹ Quý,883
+30301,Phường Mỹ Thới,883
+30304,Phường Mỹ Thạnh,883
+30307,Phường Mỹ Hòa,883
+30310,Xã Mỹ Khánh,883
+30313,Xã Mỹ Hoà Hưng,883
+30316,Phường Châu Phú B,884
+30319,Phường Châu Phú A,884
+30322,Phường Vĩnh Mỹ,884
+30325,Phường Núi Sam,884
+30328,Phường Vĩnh Ngươn,884
+30331,Xã Vĩnh Tế,884
+30334,Xã Vĩnh Châu,884
+30337,Thị trấn An Phú,886
+30340,Xã Khánh An,886
+30341,Thị Trấn Long Bình,886
+30343,Xã Khánh Bình,886
+30346,Xã Quốc Thái,886
+30349,Xã Nhơn Hội,886
+30352,Xã Phú Hữu,886
+30355,Xã Phú Hội,886
+30358,Xã Phước Hưng,886
+30361,Xã Vĩnh Lộc,886
+30364,Xã Vĩnh Hậu,886
+30367,Xã Vĩnh Trường,886
+30370,Xã Vĩnh Hội Đông,886
+30373,Xã Đa Phước,886
+30376,Phường Long Thạnh,887
+30377,Phường Long Hưng,887
+30378,Phường Long Châu,887
+30379,Xã Phú Lộc,887
+30382,Xã Vĩnh Xương,887
+30385,Xã Vĩnh Hòa,887
+30387,Xã Tân Thạnh,887
+30388,Xã Tân An,887
+30391,Xã Long An,887
+30394,Phường Long Phú,887
+30397,Xã Châu Phong,887
+30400,Xã Phú Vĩnh,887
+30403,Xã Lê Chánh,887
+30412,Phường Long Sơn,887
+30406,Thị trấn Phú Mỹ,888
+30409,Thị trấn Chợ Vàm,888
+30415,Xã Long Hoà,888
+30418,Xã Phú Long,888
+30421,Xã Phú Lâm,888
+30424,Xã Phú Hiệp,888
+30427,Xã Phú Thạnh,888
+30430,Xã Hoà Lạc,888
+30433,Xã Phú Thành,888
+30436,Xã Phú An,888
+30439,Xã Phú Xuân,888
+30442,Xã Hiệp Xương,888
+30445,Xã Phú Bình,888
+30448,Xã Phú Thọ,888
+30451,Xã Phú Hưng,888
+30454,Xã Bình Thạnh Đông,888
+30457,Xã Tân Hòa,888
+30460,Xã Tân Trung,888
+30463,Thị trấn Cái Dầu,889
+30466,Xã Khánh Hòa,889
+30469,Xã Mỹ Đức,889
+30472,Xã Mỹ Phú,889
+30475,Xã Ô Long Vỹ,889
+30478,Thị trấn Vĩnh Thạnh Trung,889
+30481,Xã Thạnh Mỹ Tây,889
+30484,Xã Bình Long,889
+30487,Xã Bình Mỹ,889
+30490,Xã Bình Thủy,889
+30493,Xã Đào Hữu Cảnh,889
+30496,Xã Bình Phú,889
+30499,Xã Bình Chánh,889
+30502,Thị trấn Nhà Bàng,890
+30505,Thị trấn Chi Lăng,890
+30508,Xã Núi Voi,890
+30511,Xã Nhơn Hưng,890
+30514,Xã An Phú,890
+30517,Xã Thới Sơn,890
+30520,Thị trấn Tịnh Biên,890
+30523,Xã Văn Giáo,890
+30526,Xã An Cư,890
+30529,Xã An Nông,890
+30532,Xã Vĩnh Trung,890
+30535,Xã Tân Lợi,890
+30538,Xã An Hảo,890
+30541,Xã Tân Lập,890
+30544,Thị trấn Tri Tôn,891
+30547,Thị trấn Ba Chúc,891
+30550,Xã Lạc Quới,891
+30553,Xã Lê Trì,891
+30556,Xã Vĩnh Gia,891
+30559,Xã Vĩnh Phước,891
+30562,Xã Châu Lăng,891
+30565,Xã Lương Phi,891
+30568,Xã Lương An Trà,891
+30571,Xã Tà Đảnh,891
+30574,Xã Núi Tô,891
+30577,Xã An Tức,891
+30580,Thị trấn Cô Tô,891
+30583,Xã Tân Tuyến,891
+30586,Xã Ô Lâm,891
+30589,Thị trấn An Châu,892
+30592,Xã An Hòa,892
+30595,Xã Cần Đăng,892
+30598,Xã Vĩnh Hanh,892
+30601,Xã Bình Thạnh,892
+30604,Thị trấn Vĩnh Bình,892
+30607,Xã Bình Hòa,892
+30610,Xã Vĩnh An,892
+30613,Xã Hòa Bình Thạnh,892
+30616,Xã Vĩnh Lợi,892
+30619,Xã Vĩnh Nhuận,892
+30622,Xã Tân Phú,892
+30625,Xã Vĩnh Thành,892
+30628,Thị trấn Chợ Mới,893
+30631,Thị trấn Mỹ Luông,893
+30634,Xã Kiến An,893
+30637,Xã Mỹ Hội Đông,893
+30640,Xã Long Điền A,893
+30643,Xã Tấn Mỹ,893
+30646,Xã Long Điền B,893
+30649,Xã Kiến Thành,893
+30652,Xã Mỹ Hiệp,893
+30655,Xã Mỹ An,893
+30658,Xã Nhơn Mỹ,893
+30661,Xã Long Giang,893
+30664,Xã Long Kiến,893
+30667,Xã Bình Phước Xuân,893
+30670,Xã An Thạnh Trung,893
+30673,Xã Hội An,893
+30676,Xã Hòa Bình,893
+30679,Xã Hòa An,893
+30682,Thị trấn Núi Sập,894
+30685,Thị trấn Phú Hoà,894
+30688,Thị Trấn Óc Eo,894
+30691,Xã Tây Phú,894
+30692,Xã An Bình,894
+30694,Xã Vĩnh Phú,894
+30697,Xã Vĩnh Trạch,894
+30700,Xã Phú Thuận,894
+30703,Xã Vĩnh Chánh,894
+30706,Xã Định Mỹ,894
+30709,Xã Định Thành,894
+30712,Xã Mỹ Phú Đông,894
+30715,Xã Vọng Đông,894
+30718,Xã Vĩnh Khánh,894
+30721,Xã Thoại Giang,894
+30724,Xã Bình Thành,894
+30727,Xã Vọng Thê,894
+30730,Phường Vĩnh Thanh Vân,899
+30733,Phường Vĩnh Thanh,899
+30736,Phường Vĩnh Quang,899
+30739,Phường Vĩnh Hiệp,899
+30742,Phường Vĩnh Bảo,899
+30745,Phường Vĩnh Lạc,899
+30748,Phường An Hòa,899
+30751,Phường An Bình,899
+30754,Phường Rạch Sỏi,899
+30757,Phường Vĩnh Lợi,899
+30760,Phường Vĩnh Thông,899
+30763,Xã Phi Thông,899
+30766,Phường Tô Châu,900
+30769,Phường Đông Hồ,900
+30772,Phường Bình San,900
+30775,Phường Pháo Đài,900
+30778,Phường Mỹ Đức,900
+30781,Xã Tiên Hải,900
+30784,Xã Thuận Yên,900
+30787,Thị trấn Kiên Lương,902
+30790,Xã Kiên Bình,902
+30802,Xã Hòa Điền,902
+30805,Xã Dương Hòa,902
+30808,Xã Bình An,902
+30809,Xã Bình Trị,902
+30811,Xã Sơn Hải,902
+30814,Xã Hòn Nghệ,902
+30817,Thị trấn Hòn Đất,903
+30820,Thị trấn Sóc Sơn,903
+30823,Xã Bình Sơn,903
+30826,Xã Bình Giang,903
+30828,Xã Mỹ Thái,903
+30829,Xã Nam Thái Sơn,903
+30832,Xã Mỹ Hiệp Sơn,903
+30835,Xã Sơn Kiên,903
+30836,Xã Sơn Bình,903
+30838,Xã Mỹ Thuận,903
+30840,Xã Lình Huỳnh,903
+30841,Xã Thổ Sơn,903
+30844,Xã Mỹ Lâm,903
+30847,Xã Mỹ Phước,903
+30850,Thị trấn Tân Hiệp,904
+30853,Xã Tân Hội,904
+30856,Xã Tân Thành,904
+30859,Xã Tân Hiệp B,904
+30860,Xã Tân Hoà,904
+30862,Xã Thạnh Đông B,904
+30865,Xã Thạnh Đông,904
+30868,Xã Tân Hiệp A,904
+30871,Xã Tân An,904
+30874,Xã Thạnh Đông A,904
+30877,Xã Thạnh Trị,904
+30880,Thị trấn Minh Lương,905
+30883,Xã Mong Thọ A,905
+30886,Xã Mong Thọ B,905
+30887,Xã Mong Thọ,905
+30889,Xã Giục Tượng,905
+30892,Xã Vĩnh Hòa Hiệp,905
+30893,Xã Vĩnh Hoà Phú,905
+30895,Xã Minh Hòa,905
+30898,Xã Bình An,905
+30901,Xã Thạnh Lộc,905
+30904,Thị Trấn Giồng Riềng,906
+30907,Xã Thạnh Hưng,906
+30910,Xã Thạnh Phước,906
+30913,Xã Thạnh Lộc,906
+30916,Xã Thạnh Hòa,906
+30917,Xã Thạnh Bình,906
+30919,Xã Bàn Thạch,906
+30922,Xã Bàn Tân Định,906
+30925,Xã Ngọc Thành,906
+30928,Xã Ngọc Chúc,906
+30931,Xã Ngọc Thuận,906
+30934,Xã Hòa Hưng,906
+30937,Xã Hoà Lợi,906
+30940,Xã Hoà An,906
+30943,Xã Long Thạnh,906
+30946,Xã Vĩnh Thạnh,906
+30947,Xã Vĩnh Phú,906
+30949,Xã  Hòa Thuận,906
+30950,Xã Ngọc Hoà,906
+30952,Thị trấn Gò Quao,907
+30955,Xã Vĩnh Hòa Hưng Bắc,907
+30958,Xã Định Hòa,907
+30961,Xã Thới Quản,907
+30964,Xã Định An,907
+30967,Xã Thủy Liễu,907
+30970,Xã Vĩnh Hòa Hưng Nam,907
+30973,Xã Vĩnh Phước A,907
+30976,Xã Vĩnh Phước B,907
+30979,Xã Vĩnh Tuy,907
+30982,Xã Vĩnh Thắng,907
+30985,Thị trấn Thứ Ba,908
+30988,Xã Tây Yên,908
+30991,Xã Tây Yên A,908
+30994,Xã Nam Yên,908
+30997,Xã Hưng Yên,908
+31000,Xã Nam Thái,908
+31003,Xã Nam Thái A,908
+31006,Xã Đông Thái,908
+31009,Xã Đông Yên,908
+31018,Thị trấn Thứ Mười Một,909
+31021,Xã Thuận Hoà,909
+31024,Xã Đông Hòa,909
+31030,Xã Đông Thạnh,909
+31031,Xã Tân Thạnh,909
+31033,Xã Đông Hưng,909
+31036,Xã Đông Hưng A,909
+31039,Xã Đông Hưng B,909
+31042,Xã Vân Khánh,909
+31045,Xã Vân Khánh Đông,909
+31048,Xã Vân Khánh Tây,909
+31051,Thị trấn Vĩnh Thuận,910
+31060,Xã Vĩnh Bình Bắc,910
+31063,Xã Vĩnh Bình Nam,910
+31064,Xã Bình Minh,910
+31069,Xã Vĩnh Thuận,910
+31072,Xã Tân Thuận,910
+31074,Xã Phong Đông,910
+31075,Xã Vĩnh Phong,910
+31078,Phường Dương Đông,911
+31081,Phường An Thới,911
+31084,Xã Cửa Cạn,911
+31087,Xã Gành Dầu,911
+31090,Xã Cửa Dương,911
+31093,Xã Hàm Ninh,911
+31096,Xã Dương Tơ,911
+31102,Xã Bãi Thơm,911
+31105,Xã Thổ Châu,911
+31108,Xã Hòn Tre,912
+31111,Xã Lại Sơn,912
+31114,Xã An Sơn,912
+31115,Xã Nam Du,912
+31012,Xã Thạnh Yên,913
+31015,Xã Thạnh Yên A,913
+31027,Xã An Minh Bắc,913
+31054,Xã Vĩnh Hòa,913
+31057,Xã Hoà Chánh,913
+31066,Xã Minh Thuận,913
+30791,Xã Vĩnh Phú,914
+30793,Xã Vĩnh Điều,914
+30796,Xã Tân Khánh Hòa,914
+30797,Xã Phú Lợi,914
+30799,Xã Phú Mỹ,914
+31117,Phường Cái Khế,916
+31120,Phường An Hòa,916
+31123,Phường Thới Bình,916
+31126,Phường An Nghiệp,916
+31129,Phường An Cư,916
+31135,Phường Tân An,916
+31141,Phường An Phú,916
+31144,Phường Xuân Khánh,916
+31147,Phường Hưng Lợi,916
+31149,Phường An Khánh,916
+31150,Phường An Bình,916
+31153,Phường Châu Văn Liêm,917
+31154,Phường Thới Hòa,917
+31156,Phường Thới Long,917
+31157,Phường Long Hưng,917
+31159,Phường Thới An,917
+31162,Phường Phước Thới,917
+31165,Phường Trường Lạc,917
+31168,Phường Bình Thủy,918
+31169,Phường Trà An,918
+31171,Phường Trà Nóc,918
+31174,Phường Thới An Đông,918
+31177,Phường An Thới,918
+31178,Phường Bùi Hữu Nghĩa,918
+31180,Phường Long Hòa,918
+31183,Phường Long Tuyền,918
+31186,Phường Lê Bình,919
+31189,Phường Hưng Phú,919
+31192,Phường Hưng Thạnh,919
+31195,Phường Ba Láng,919
+31198,Phường Thường Thạnh,919
+31201,Phường Phú Thứ,919
+31204,Phường Tân Phú,919
+31207,Phường Thốt Nốt,923
+31210,Phường Thới Thuận,923
+31212,Phường Thuận An,923
+31213,Phường Tân Lộc,923
+31216,Phường Trung Nhứt,923
+31217,Phường Thạnh Hoà,923
+31219,Phường Trung Kiên,923
+31227,Phường Tân Hưng,923
+31228,Phường Thuận Hưng,923
+31211,Xã Vĩnh Bình,924
+31231,Thị trấn Thanh An,924
+31232,Thị trấn Vĩnh Thạnh,924
+31234,Xã Thạnh Mỹ,924
+31237,Xã Vĩnh Trinh,924
+31240,Xã Thạnh An,924
+31241,Xã Thạnh Tiến,924
+31243,Xã Thạnh Thắng,924
+31244,Xã Thạnh Lợi,924
+31246,Xã Thạnh Qưới,924
+31252,Xã Thạnh Lộc,924
+31222,Xã Trung An,925
+31225,Xã Trung Thạnh,925
+31249,Xã Thạnh Phú,925
+31255,Xã Trung Hưng,925
+31261,Thị trấn Cờ Đỏ,925
+31264,Xã Thới Hưng,925
+31273,Xã Đông Hiệp,925
+31274,Xã Đông Thắng,925
+31276,Xã Thới Đông,925
+31277,Xã Thới Xuân,925
+31299,Thị trấn Phong Điền,926
+31300,Xã Nhơn Ái,926
+31303,Xã Giai Xuân,926
+31306,Xã Tân Thới,926
+31309,Xã Trường Long,926
+31312,Xã Mỹ Khánh,926
+31315,Xã Nhơn Nghĩa,926
+31258,Thị trấn Thới Lai,927
+31267,Xã Thới Thạnh,927
+31268,Xã Tân Thạnh,927
+31270,Xã Xuân Thắng,927
+31279,Xã Đông Bình,927
+31282,Xã Đông Thuận,927
+31285,Xã Thới Tân,927
+31286,Xã Trường Thắng,927
+31288,Xã Định Môn,927
+31291,Xã Trường Thành,927
+31294,Xã Trường Xuân,927
+31297,Xã Trường Xuân A,927
+31298,Xã Trường Xuân B,927
+31318,Phường I,930
+31321,Phường III,930
+31324,Phường IV,930
+31327,Phường V,930
+31330,Phường VII,930
+31333,Xã Vị Tân,930
+31336,Xã Hoả Lựu,930
+31338,Xã Tân Tiến,930
+31339,Xã Hoả Tiến,930
+31340,Phường Ngã Bảy,931
+31341,Phường Lái Hiếu,931
+31343,Phường Hiệp Thành,931
+31344,Phường Hiệp Lợi,931
+31411,Xã Đại Thành,931
+31414,Xã Tân Thành,931
+31342,Thị trấn Một Ngàn,932
+31345,Xã Tân Hoà,932
+31346,Thị trấn Bảy Ngàn,932
+31348,Xã Trường Long Tây,932
+31351,Xã Trường Long A,932
+31357,Xã Nhơn Nghĩa A,932
+31359,Thị trấn Rạch Gòi,932
+31360,Xã Thạnh Xuân,932
+31362,Thị trấn Cái Tắc,932
+31363,Xã Tân Phú Thạnh,932
+31366,Thị Trấn Ngã Sáu,933
+31369,Xã Đông Thạnh,933
+31375,Xã Đông Phú,933
+31378,Xã Phú Hữu,933
+31379,Xã Phú Tân,933
+31381,Thị trấn Mái Dầm,933
+31384,Xã Đông Phước,933
+31387,Xã Đông Phước A,933
+31393,Thị trấn Kinh Cùng,934
+31396,Thị trấn Cây Dương,934
+31399,Xã Tân Bình,934
+31402,Xã Bình Thành,934
+31405,Xã Thạnh Hòa,934
+31408,Xã Long Thạnh,934
+31417,Xã Phụng Hiệp,934
+31420,Xã Hòa Mỹ,934
+31423,Xã Hòa An,934
+31426,Xã Phương Bình,934
+31429,Xã Hiệp Hưng,934
+31432,Xã Tân Phước Hưng,934
+31433,Thị trấn Búng Tàu,934
+31435,Xã Phương Phú,934
+31438,Xã Tân Long,934
+31441,Thị trấn Nàng Mau,935
+31444,Xã Vị Trung,935
+31447,Xã Vị Thuỷ,935
+31450,Xã Vị Thắng,935
+31453,Xã Vĩnh Thuận Tây,935
+31456,Xã Vĩnh Trung,935
+31459,Xã Vĩnh Tường,935
+31462,Xã Vị Đông,935
+31465,Xã Vị Thanh,935
+31468,Xã Vị Bình,935
+31483,Xã Thuận Hưng,936
+31484,Xã Thuận Hòa,936
+31486,Xã Vĩnh Thuận Đông,936
+31489,Thị trấn Vĩnh Viễn,936
+31490,Xã Vĩnh Viễn A,936
+31492,Xã Lương Tâm,936
+31493,Xã Lương Nghĩa,936
+31495,Xã Xà Phiên,936
+31471,Phường Thuận An,937
+31472,Phường Trà Lồng,937
+31473,Phường Bình Thạnh,937
+31474,Xã Long Bình,937
+31475,Phường Vĩnh Tường,937
+31477,Xã Long Trị,937
+31478,Xã Long Trị A,937
+31480,Xã Long Phú,937
+31481,Xã Tân Phú,937
+31498,Phường 5,941
+31501,Phường 7,941
+31504,Phường 8,941
+31507,Phường 6,941
+31510,Phường 2,941
+31513,Phường 1,941
+31516,Phường 4,941
+31519,Phường 3,941
+31522,Phường 9,941
+31525,Phường 10,941
+31569,Thị trấn Châu Thành,942
+31570,Xã Hồ Đắc Kiện,942
+31573,Xã Phú Tâm,942
+31576,Xã Thuận Hòa,942
+31582,Xã Phú Tân,942
+31585,Xã Thiện Mỹ,942
+31594,Xã An Hiệp,942
+31600,Xã An Ninh,942
+31528,Thị trấn Kế Sách,943
+31531,Thị trấn An Lạc Thôn,943
+31534,Xã Xuân Hòa,943
+31537,Xã Phong Nẫm,943
+31540,Xã An Lạc Tây,943
+31543,Xã Trinh Phú,943
+31546,Xã Ba Trinh,943
+31549,Xã Thới An Hội,943
+31552,Xã Nhơn Mỹ,943
+31555,Xã Kế Thành,943
+31558,Xã Kế An,943
+31561,Xã Đại Hải,943
+31564,Xã An Mỹ,943
+31567,Thị trấn Huỳnh Hữu Nghĩa,944
+31579,Xã Long Hưng,944
+31588,Xã Hưng Phú,944
+31591,Xã Mỹ Hương,944
+31597,Xã Mỹ Tú,944
+31603,Xã Mỹ Phước,944
+31606,Xã Thuận Hưng,944
+31609,Xã Mỹ Thuận,944
+31612,Xã Phú Mỹ,944
+31615,Thị trấn Cù Lao Dung,945
+31618,Xã An Thạnh 1,945
+31621,Xã An Thạnh Tây,945
+31624,Xã An Thạnh Đông,945
+31627,Xã Đại Ân 1,945
+31630,Xã An Thạnh 2,945
+31633,Xã An Thạnh 3,945
+31636,Xã An Thạnh Nam,945
+31639,Thị trấn Long Phú,946
+31642,Xã Song Phụng,946
+31645,Thị trấn Đại Ngãi,946
+31648,Xã Hậu Thạnh,946
+31651,Xã Long Đức,946
+31654,Xã Trường Khánh,946
+31657,Xã Phú Hữu,946
+31660,Xã Tân Hưng,946
+31663,Xã Châu Khánh,946
+31666,Xã Tân Thạnh,946
+31669,Xã Long Phú,946
+31684,Thị trấn Mỹ Xuyên,947
+31690,Xã Đại Tâm,947
+31693,Xã Tham Đôn,947
+31708,Xã Thạnh Phú,947
+31711,Xã Ngọc Đông,947
+31714,Xã Thạnh Quới,947
+31717,Xã Hòa Tú 1,947
+31720,Xã Gia Hòa 1,947
+31723,Xã Ngọc Tố,947
+31726,Xã Gia Hòa 2,947
+31729,Xã Hòa Tú II,947
+31732,Phường 1,948
+31735,Phường 2,948
+31738,Xã Vĩnh Quới,948
+31741,Xã Tân Long,948
+31744,Xã Long Bình,948
+31747,Phường 3,948
+31750,Xã Mỹ Bình,948
+31753,Xã Mỹ Quới,948
+31756,Thị trấn Phú Lộc,949
+31757,Thị trấn Hưng Lợi,949
+31759,Xã Lâm Tân,949
+31762,Xã Thạnh Tân,949
+31765,Xã Lâm Kiết,949
+31768,Xã Tuân Tức,949
+31771,Xã Vĩnh Thành,949
+31774,Xã Thạnh Trị,949
+31777,Xã Vĩnh Lợi,949
+31780,Xã Châu Hưng,949
+31783,Phường 1,950
+31786,Xã Hòa Đông,950
+31789,Phường Khánh Hòa,950
+31792,Xã Vĩnh Hiệp,950
+31795,Xã Vĩnh Hải,950
+31798,Xã Lạc Hòa,950
+31801,Phường 2,950
+31804,Phường Vĩnh Phước,950
+31807,Xã Vĩnh Tân,950
+31810,Xã Lai Hòa,950
+31672,Xã Đại Ân  2,951
+31673,Thị trấn Trần Đề,951
+31675,Xã Liêu Tú,951
+31678,Xã Lịch Hội Thượng,951
+31679,Thị trấn Lịch Hội Thượng,951
+31681,Xã Trung Bình,951
+31687,Xã Tài Văn,951
+31696,Xã Viên An,951
+31699,Xã Thạnh Thới An,951
+31702,Xã Thạnh Thới Thuận,951
+31705,Xã Viên Bình,951
+31813,Phường 2,954
+31816,Phường 3,954
+31819,Phường 5,954
+31822,Phường 7,954
+31825,Phường 1,954
+31828,Phường 8,954
+31831,Phường Nhà Mát,954
+31834,Xã Vĩnh Trạch,954
+31837,Xã Vĩnh Trạch Đông,954
+31840,Xã Hiệp Thành,954
+31843,Thị trấn Ngan Dừa,956
+31846,Xã Ninh Quới,956
+31849,Xã Ninh Quới A,956
+31852,Xã Ninh Hòa,956
+31855,Xã Lộc Ninh,956
+31858,Xã Vĩnh Lộc,956
+31861,Xã Vĩnh Lộc A,956
+31863,Xã Ninh Thạnh Lợi A,956
+31864,Xã Ninh Thạnh Lợi,956
+31867,Thị trấn Phước Long,957
+31870,Xã Vĩnh Phú Đông,957
+31873,Xã Vĩnh Phú Tây,957
+31876,Xã Phước Long,957
+31879,Xã Hưng Phú,957
+31882,Xã Vĩnh Thanh,957
+31885,Xã Phong Thạnh Tây A,957
+31888,Xã Phong Thạnh Tây B,957
+31894,Xã Vĩnh Hưng,958
+31897,Xã Vĩnh Hưng A,958
+31900,Thị trấn Châu Hưng,958
+31903,Xã Châu Hưng A,958
+31906,Xã Hưng Thành,958
+31909,Xã Hưng Hội,958
+31912,Xã Châu Thới,958
+31921,Xã Long Thạnh,958
+31942,Phường 1,959
+31945,Phường Hộ Phòng,959
+31948,Xã Phong Thạnh Đông,959
+31951,Phường Láng Tròn,959
+31954,Xã Phong Tân,959
+31957,Xã Tân Phong,959
+31960,Xã Phong Thạnh,959
+31963,Xã Phong Thạnh A,959
+31966,Xã Phong Thạnh Tây,959
+31969,Xã Tân Thạnh,959
+31972,Thị trấn Gành Hào,960
+31975,Xã Long Điền Đông,960
+31978,Xã Long Điền Đông A,960
+31981,Xã Long Điền,960
+31984,Xã Long Điền Tây,960
+31985,Xã Điền Hải,960
+31987,Xã An Trạch,960
+31988,Xã An Trạch A,960
+31990,Xã An Phúc,960
+31993,Xã Định Thành,960
+31996,Xã Định Thành A,960
+31891,Thị trấn Hòa Bình,961
+31915,Xã Minh Diệu,961
+31918,Xã Vĩnh Bình,961
+31924,Xã Vĩnh Mỹ B,961
+31927,Xã Vĩnh Hậu,961
+31930,Xã Vĩnh Hậu A,961
+31933,Xã Vĩnh Mỹ A,961
+31936,Xã Vĩnh Thịnh,961
+31999,Phường 9,964
+32002,Phường 4,964
+32005,Phường 1,964
+32008,Phường 5,964
+32011,Phường 2,964
+32014,Phường 8,964
+32017,Phường 6,964
+32020,Phường 7,964
+32022,Phường Tân Xuyên,964
+32023,Xã An Xuyên,964
+32025,Phường Tân Thành,964
+32026,Xã Tân Thành,964
+32029,Xã Tắc Vân,964
+32032,Xã Lý Văn Lâm,964
+32035,Xã Định Bình,964
+32038,Xã Hòa Thành,964
+32041,Xã Hòa Tân,964
+32044,Thị trấn U Minh,966
+32047,Xã Khánh Hòa,966
+32048,Xã Khánh Thuận,966
+32050,Xã Khánh Tiến,966
+32053,Xã Nguyễn Phích,966
+32056,Xã Khánh Lâm,966
+32059,Xã Khánh An,966
+32062,Xã Khánh Hội,966
+32065,Thị trấn Thới Bình,967
+32068,Xã Biển Bạch,967
+32069,Xã Tân Bằng,967
+32071,Xã Trí Phải,967
+32072,Xã Trí Lực,967
+32074,Xã Biển Bạch Đông,967
+32077,Xã Thới Bình,967
+32080,Xã Tân Phú,967
+32083,Xã Tân Lộc Bắc,967
+32086,Xã Tân Lộc,967
+32089,Xã Tân Lộc Đông,967
+32092,Xã Hồ Thị Kỷ,967
+32095,Thị trấn Trần Văn Thời,968
+32098,Thị trấn Sông Đốc,968
+32101,Xã Khánh Bình Tây Bắc,968
+32104,Xã Khánh Bình Tây,968
+32107,Xã Trần Hợi,968
+32108,Xã Khánh Lộc,968
+32110,Xã Khánh Bình,968
+32113,Xã Khánh Hưng,968
+32116,Xã Khánh Bình Đông,968
+32119,Xã Khánh Hải,968
+32122,Xã Lợi An,968
+32124,Xã Phong Điền,968
+32125,Xã Phong Lạc,968
+32128,Thị trấn Cái Nước,969
+32130,Xã Thạnh Phú,969
+32131,Xã Lương Thế Trân,969
+32134,Xã Phú Hưng,969
+32137,Xã Tân Hưng,969
+32140,Xã Hưng Mỹ,969
+32141,Xã Hoà Mỹ,969
+32142,Xã Đông Hưng,969
+32143,Xã Đông Thới,969
+32146,Xã Tân Hưng Đông,969
+32149,Xã Trần Thới,969
+32152,Thị trấn Đầm Dơi,970
+32155,Xã Tạ An Khương,970
+32158,Xã Tạ An Khương  Đông,970
+32161,Xã Trần Phán,970
+32162,Xã Tân Trung,970
+32164,Xã Tân Đức,970
+32167,Xã Tân Thuận,970
+32170,Xã Tạ An Khương  Nam,970
+32173,Xã Tân Duyệt,970
+32174,Xã Tân Dân,970
+32176,Xã Tân Tiến,970
+32179,Xã Quách Phẩm Bắc,970
+32182,Xã Quách Phẩm,970
+32185,Xã Thanh Tùng,970
+32186,Xã Ngọc Chánh,970
+32188,Xã Nguyễn Huân,970
+32191,Thị Trấn Năm Căn,971
+32194,Xã Hàm Rồng,971
+32197,Xã Hiệp Tùng,971
+32200,Xã Đất Mới,971
+32201,Xã Lâm Hải,971
+32203,Xã Hàng Vịnh,971
+32206,Xã Tam Giang,971
+32209,Xã Tam Giang Đông,971
+32212,Thị trấn Cái Đôi Vàm,972
+32214,Xã Phú Thuận,972
+32215,Xã Phú Mỹ,972
+32218,Xã Phú Tân,972
+32221,Xã Tân Hải,972
+32224,Xã Việt Thắng,972
+32227,Xã Tân Hưng Tây,972
+32228,Xã Rạch Chèo,972
+32230,Xã Nguyễn Việt Khái,972
+32233,Xã Tam Giang Tây,973
+32236,Xã Tân Ân Tây,973
+32239,Xã Viên An Đông,973
+32242,Xã Viên An,973
+32244,Thị trấn Rạch Gốc,973
+32245,Xã Tân Ân,973
+32248,Xã Đất Mũi,973

--- a/src/backend/package-lock.json
+++ b/src/backend/package-lock.json
@@ -16,6 +16,7 @@
         "google-auth-library": "^8.0.3",
         "jsonwebtoken": "^8.5.1",
         "knex": "^2.1.0",
+        "nodemailer": "^6.7.6",
         "nodemon": "^2.0.16",
         "pg": "^8.7.3"
       }
@@ -1636,6 +1637,14 @@
       "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
       "engines": {
         "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.7.6",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.7.6.tgz",
+      "integrity": "sha512-/6KF/umU7r7X21Y648/yiRLrgkfz0dmpyuo4BfgYWIpnT/jCbkPTvegMfxCsDAu+O810p2L1BGXieMTPp3nJVA==",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {
@@ -3732,6 +3741,11 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
       "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
+    },
+    "nodemailer": {
+      "version": "6.7.6",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.7.6.tgz",
+      "integrity": "sha512-/6KF/umU7r7X21Y648/yiRLrgkfz0dmpyuo4BfgYWIpnT/jCbkPTvegMfxCsDAu+O810p2L1BGXieMTPp3nJVA=="
     },
     "nodemon": {
       "version": "2.0.16",

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -18,6 +18,7 @@
     "google-auth-library": "^8.0.3",
     "jsonwebtoken": "^8.5.1",
     "knex": "^2.1.0",
+    "nodemailer": "^6.7.6",
     "nodemon": "^2.0.16",
     "pg": "^8.7.3"
   }

--- a/src/backend/src/config/config.js
+++ b/src/backend/src/config/config.js
@@ -17,7 +17,13 @@ const config = {
     PORT: 8080,
     JWT_EXP_TIME: 60 * 60 * 24,
     JWT_SECRET: process.env.JWT_SECRET,
+
     GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
+    GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET,
+    GOOGLE_REFRESH_TOKEN: process.env.GOOGLE_REFRESH_TOKEN,
+
+    GMAIL_USERNAME: process.env.GMAIL_USERNAME,
+    
     BEST_SELLER_LIMIT: 8,
 }
 

--- a/src/backend/src/controller/auth.controller.js
+++ b/src/backend/src/controller/auth.controller.js
@@ -1,28 +1,47 @@
 import account from '#src/models/account.model'
 import jwt from 'jsonwebtoken'
 import config from '#src/config/config'
-import { OAuth2Client } from 'google-auth-library'
-import sha256 from 'crypto-js/sha256.js'
-
-const client = new OAuth2Client(config.GOOGLE_CLIENT_ID)
+import CryptoJS from 'crypto-js'
+import oauth2Client from '#src/utils/oauth2'
+import mailer from '#src/utils/nodemailer'
 
 export default {
     async login(req, res) {
-        const email = req.body.email
-        const password = req.body.password
         try {
-            const correctPassword = await account.getPassword(email);
-            const hashPassword = sha256(password).toString();
-            if (correctPassword === null || hashPassword !== correctPassword) {
+            const email = req.body.email
+            const password = req.body.password
+
+            // Get the database password
+            const encryptedPassword = await account.getPassword(email);
+            if (encryptedPassword === null) {
                 res.status(200).send({
                     exitcode: 3,
                     message: "Email or password is not correct"
                 });
                 return;
             }
+
+            // Get salt
+            const encryptedWordArray = CryptoJS.enc.Base64.parse(encryptedPassword)
+            const [salt, hashedCorrectPassword] = CryptoJS.enc.Utf8.stringify(encryptedWordArray).split("&")
+            console.log(salt, hashedCorrectPassword)
+
+            // Compare the password
+            const hashedPassword = CryptoJS.SHA256(salt + password).toString();
+            if (hashedPassword !== hashedCorrectPassword) {
+                res.status(200).send({
+                    exitcode: 3,
+                    message: "Email or password is not correct"
+                });
+                return;
+            }
+
+            // Create payload for encryption
             const payload = {
                 email: email
             }
+
+            // Send back response with token
             res.status(200).send({
                 exitcode: 0,
                 message: "Login successfully",
@@ -40,9 +59,10 @@ export default {
     },
 
     async signup(req, res) {
-        const { email, phone, password, fullname, address } = req.body;
-
         try {
+            const { email, phone, password, fullname } = req.body;
+
+            // Check for email duplicated
             const emailAccount = await account.getByEmail(email);
             if (emailAccount !== null) {
                 res.status(200).send({
@@ -52,6 +72,7 @@ export default {
                 return;
             }
 
+            // Check for phone duplicated
             const phoneAccount = await account.getByPhone(phone);
             if (phoneAccount !== null) {
                 res.status(200).send({
@@ -61,11 +82,65 @@ export default {
                 return;
             }
 
-            const hashedPassword = sha256(password).toString();
+            // 256 bits which provides about 1e+77 possible different number
+            // This is enough for preventing brute force
+            const nByteToken = 256 / 8;
+            const token = CryptoJS.lib.WordArray.random(nByteToken).toString();
+
+            // Encrypt password by salting and hashing
+            const nByteSalt = 16 / 8
+            const salt = CryptoJS.lib.WordArray.random(nByteSalt).toString();
+            const hashedPassword = CryptoJS.SHA256(salt + password).toString();
+            const finalWordArray = CryptoJS.enc.Utf8.parse([salt, hashedPassword].join("&"))
+            const finalPassword = CryptoJS.enc.Base64.stringify(finalWordArray)
+
+            // Send the time for each mail is different
+            // This prevent the html being trimmed by Gmail
+            const mailOption = {
+                from: config.GMAIL_USERNAME,
+                to: email,
+                subject: "[Huimitu] Email verification",
+                html: `
+                <div style="
+                    text-align: center; 
+                    height: 256px;
+                    width: 512px;
+                    background-color: hsl(125, 29%, 75%); 
+                    padding: 2em; 
+                    justify-content: center;"
+                >
+                    <h1>Huimitu Shop</h1>
+                    <h3>Thank you for registering</h3>
+                    <div>
+                        <a href="http://${req.headers.host}/account/verify/${token}">
+                            <button style="
+                                font-weight: bold; 
+                                padding: 2em; 
+                                background-color: #18aeac; 
+                                color: #fff; 
+                                width: 512px; 
+                                border: none;"
+                            >
+                                Click here to activate your account
+                            </button>
+                        </a>
+                    </div>
+                    <div>Sent at ${(new Date()).toUTCString()}</div>
+                </div>`
+            }
+            // await mailer.sendMail(mailOption);
+
+            // Create entity to insert to DB
             const entity = {
-                email, phone, fullname, address, password: hashedPassword
+                email,
+                phone,
+                fullname,
+                password: finalPassword,
+                verified: false,
+                token: token
             }
             const result = await account.signup(entity)
+
             res.status(200).send({
                 exitcode: 0,
                 message: "Create account successfully"
@@ -80,13 +155,15 @@ export default {
     },
 
     async loginGoogle(req, res) {
-        const { tokenId } = req.body;
-
         try {
-            const result = await client.verifyIdToken({
+            // Extract and verify token from Google
+            const { tokenId } = req.body;
+            const result = await oauth2Client.verifyIdToken({
                 idToken: tokenId,
                 audience: config.GOOGLE_CLIENT_ID
             })
+
+            // Create new account if email not registered
             const { email } = result.payload;
             const currentAccount = await account.getByEmail(email);
             if (currentAccount === null) {
@@ -95,6 +172,8 @@ export default {
                 }
                 await account.signup(newAccount);
             }
+
+            // Sign a new token by server
             const payload = {
                 email: email
             }

--- a/src/backend/src/models/account.model.js
+++ b/src/backend/src/models/account.model.js
@@ -13,20 +13,28 @@ export default {
     },
 
     async signup(data) {
-        return db('account').insert(data);
+        const entity = {
+            fullname: data.fullname,
+            email: data.email,
+            password: data.password,
+            phone: data.phone,
+            verified: data.verified,
+            token: data.token
+        }
+        return db('account').insert(entity);
     },
 
     async getByEmail(email) {
         const result = await db('account').where({
             email: email
         })
-        return result[0]
+        return result[0] || null;
     },
 
     async getByPhone(phone) {
         const result = await db('account').where({
             phone: phone
         })
-        return result[0];
+        return result[0] || null;
     }
 }

--- a/src/backend/src/utils/nodemailer.js
+++ b/src/backend/src/utils/nodemailer.js
@@ -1,0 +1,17 @@
+import config from '#src/config/config'
+import nodemailer from 'nodemailer'
+import oauthClient from '#src/utils/oauth2'
+
+const accessToken = oauthClient.getAccessToken()
+
+export default nodemailer.createTransport({
+    service: 'gmail',
+    auth: {
+        type: 'OAuth2',
+        user: config.GMAIL_USERNAME,
+        clientId: config.GOOGLE_CLIENT_ID,
+        clientSecret: config.GOOGLE_CLIENT_SECRET,
+        refreshToken: config.GOOGLE_REFRESH_TOKEN,
+        accessToken: accessToken.token
+    },
+})

--- a/src/backend/src/utils/oauth2.js
+++ b/src/backend/src/utils/oauth2.js
@@ -1,0 +1,9 @@
+import { OAuth2Client } from 'google-auth-library'
+import config from '#src/config/config'
+
+const oauth2Client = new OAuth2Client(config.GOOGLE_CLIENT_ID, config.GOOGLE_CLIENT_SECRET)
+oauth2Client.setCredentials({
+    refresh_token: config.GOOGLE_REFRESH_TOKEN
+})
+
+export default oauth2Client


### PR DESCRIPTION
Need to review
- Hashing password with salt
- Create mail for verification

Why using salt: If only hash, the two hashed password have are the same which can deduct into the raw password are the same. Furthermore, this can be face with "dictionary-attack".